### PR TITLE
feat(system-profile): UC ecosystem hardware scanner + storage reserva…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-## Unreleased - 2026-05-14 - 2026-05-16
+## Unreleased - 2026-05-14 - 2026-05-18
+
+### New Features — UC System Profile
+
+The launcher can now scan your PC's hardware and use it across the whole UC ecosystem: pre-download requirement checks, library filtering, opt-in spec badges on comments/forums, multi-rig device switching, and crash-report enrichment. Nothing leaves your machine until you flip an online sharing switch.
+
+- **Hardware scanner** (Settings → System Profile → Scan now). Detects CPU, GPU(s) with VRAM and driver date, RAM (total / speed / channels), all drives with NVMe/SSD/HDD media type, OS build, displays (resolution + refresh rate), and DirectX/Vulkan versions. Uses platform-native tools only — no new npm dependencies, no native rebuild required. PowerShell-based on Windows, `/proc` + `lscpu`/`lspci` on Linux. A fingerprint hash detects when the PC has changed and prompts for a rescan.
+- **Pre-download requirement check** in the Download dialog. When a game has system requirements published, the modal now shows a per-component pass/warn/fail comparison against your scanned hardware. Can be disabled from Settings → System Profile → Pre-download requirement check.
+- **Storage reservation for downloads**. UC.D now refuses to start a download when the target drive doesn't have room for the archive PLUS the extracted install (estimated as 2× archive size, or the declared install size when known, plus a 5%/2GB safety buffer). Concurrent downloads now correctly account for each other's reservations on the same drive — no more double-booking free space. Reservations are released on cancel, error, or extraction completion.
+- **Storage-type hint** in the Download dialog. When you're installing a 30GB+ game to an HDD and you have an SSD/NVMe drive available, the dialog now suggests switching the download path. Best-effort on Windows (uses Storage Spaces cmdlets to map drive letters to physical media); not yet wired on Linux.
+- **GPU driver staleness warning** in the Download dialog. Warns when your GPU driver is more than 6 months old and links to the NVIDIA / AMD / Intel / Apple driver page based on the detected vendor.
+- **System Profile settings panel** (new section in Settings sidebar) with per-surface visibility toggles: Comment badge / Forum posts (off · summary) and Public profile card (off · summary · full). The pre-download check toggle is local-only and on by default.
+- **Server sync** — when at least one online surface is set above "Off", scans are automatically uploaded to UC. Visibility state is mirrored to the server so other UC surfaces (game pages, forum posts) can render your specs at the tier you allowed. Clearing the local cache or flipping every surface back to "Off" deletes the server copy.
+- **Multi-rig device picker** — when you've scanned more than one device, a "My PCs" card lets you pick which rig is treated as your active profile. Rename and forget controls per device. Uploads tag the device with `hostname()` by default.
+- **Share-a-spec links** — mint a short URL (`/specs/abc12345`) anyone can open to see your specs frozen at create time. Useful for "can your friend's PC run this?" conversations. Summary or Full tier per link, revokable from Settings.
+- **Upgrade suggester** — analyses your UC wishlist against your active profile, identifies the biggest bottleneck component, and suggests a coarse next-tier upgrade (e.g. "Upgrade GTX 1060 → RTX 3060 / RX 6700-class card · would unlock 7 wishlisted games"). Only shown when at least one online surface is on.
+- **Per-post specs toggle** on comment and forum forms — each post can override the global visibility setting. Defaults match your global tier so unchanged behavior stays consistent.
+- **Crash report enrichment** — when sharing diagnostics (Settings → Account → Privacy → Send error reports), an optional one-line hardware summary ("RTX 4070 · 32GB · Win11") is attached so the dev team can reproduce platform-specific issues. Opt-out via the new "Include hardware summary in error reports" toggle.
+- **`unioncrax://scan` deep link** — clicking "Scan in UC.Direct" from the website now opens UC.D, navigates straight to Settings → System Profile, and triggers a fresh scan. Extends the existing `unioncrax://launch` handler with a navigation-action queue that drains once the main window finishes loading.
+- **Website parity surfaces** (cross-repo with `union-crax.xyz`): the website's download dialog now shows the same per-component pass/warn/fail sysreq comparison UC.D's download modal does, the `/settings` page gains a full "System Profile" section mirroring UC.D's panel (visibility toggles, multi-rig device picker, share-a-spec links, upgrade suggestions) — minus scanning, which it delegates back to UC.D via the deep link. Web "Scan in UC.Direct" buttons follow the same install-detection pattern as the existing "Open in UC.D" button.
 
 ### Fixes & Improvements
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -13,6 +13,8 @@ try {
 }
 const DiscordRPC = require('discord-rpc')
 const { autoUpdater } = require('electron-updater')
+const systemProfileScanner = require('./system-profile.cjs')
+const storageReservation = require('./storage-reservation.cjs')
 
 const packageJson = require('../package.json')
 const isDev = !app.isPackaged
@@ -172,6 +174,7 @@ function unregisterExtractionJob(jobOrDownloadId) {
   if (!job) return null
   extractionJobs.delete(job.downloadId)
   for (const key of job.keys || []) activeExtractions.delete(key)
+  try { storageReservation.release(job.downloadId) } catch { }
   refreshOperationPowerSaveBlocker()
   return job
 }
@@ -1560,6 +1563,20 @@ function applySettingsDefaults(settings) {
   if (!next.libraryGameMeta || typeof next.libraryGameMeta !== 'object' || Array.isArray(next.libraryGameMeta)) {
     next.libraryGameMeta = {}
   }
+  if (!next.systemProfileVisibility || typeof next.systemProfileVisibility !== 'object' || Array.isArray(next.systemProfileVisibility)) {
+    // Tiered visibility per surface. Defaults are conservative: scanner
+    // results stay private until the user opts in on each surface.
+    next.systemProfileVisibility = {
+      comments: 'off',       // off | summary | full
+      forums: 'off',
+      profilePublic: 'off',
+      sysreqCheck: 'on',     // local pre-download check — no PII leaves device
+    }
+  }
+  if (typeof next.systemProfileSyncEnabled !== 'boolean') next.systemProfileSyncEnabled = false
+  // When sharing error logs / diagnostics, optionally include a one-line hardware
+  // summary so the dev team can see what platform the issue happened on.
+  if (typeof next.attachSystemProfileToLogs !== 'boolean') next.attachSystemProfileToLogs = true
   return next
 }
 
@@ -2074,6 +2091,10 @@ let mainWindow = null
 const UC_DEEP_LINK_SCHEME = 'unioncrax'
 let pendingAppLaunchRequests = []
 let processingLaunchQueue = false
+// Queued one-shot navigation actions delivered to the renderer once the
+// main window is ready. Currently just 'system-profile' from the web's
+// "Scan with UC.Direct" button.
+let pendingNavigationActions = []
 
 function normalizeAppid(value) {
   if (value == null) return null
@@ -2113,6 +2134,34 @@ function parseLaunchRequestFromDeepLink(rawUrl) {
   }
 }
 
+/**
+ * Parse `unioncrax://scan` (or `://settings/system-profile`) deep links
+ * from the web's "Scan in UC.Direct" buttons. Returns a navigation action
+ * the renderer can act on once it loads.
+ */
+function parseNavigationActionFromDeepLink(rawUrl) {
+  try {
+    const parsed = new URL(String(rawUrl || ''))
+    if (parsed.protocol !== `${UC_DEEP_LINK_SCHEME}:`) return null
+    const segment = String(parsed.hostname || parsed.pathname.replace(/^\/+/, '').split('/')[0] || '').toLowerCase()
+    if (segment === 'scan' || segment === 'system-profile') {
+      return { action: 'open-system-profile', autoScan: segment === 'scan' || parsed.searchParams.get('rescan') === '1' }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function enqueueNavigationAction(action) {
+  if (!action || !action.action) return
+  // Collapse duplicates — a queued open-system-profile request shouldn't fire twice.
+  const exists = pendingNavigationActions.some((a) => a.action === action.action)
+  if (exists) return
+  pendingNavigationActions.push({ ...action, queuedAt: Date.now() })
+  ucLog(`Queued navigation action: ${action.action}${action.autoScan ? ' (autoScan)' : ''}`)
+}
+
 function parseLaunchRequestFromArgv(argv) {
   const appidFromFlag = parseLaunchAppidFromArgv(argv)
   if (appidFromFlag) return { appid: appidFromFlag, source: 'cli-flag' }
@@ -2122,6 +2171,15 @@ function parseLaunchRequestFromArgv(argv) {
     if (maybe?.appid) {
       return { appid: maybe.appid, source: 'protocol-argv', rawUrl: maybe.rawUrl }
     }
+  }
+  return null
+}
+
+function parseNavigationActionFromArgv(argv) {
+  if (!Array.isArray(argv)) return null
+  for (const arg of argv) {
+    const maybe = parseNavigationActionFromDeepLink(arg)
+    if (maybe) return maybe
   }
   return null
 }
@@ -2319,6 +2377,32 @@ function buildUcOwnedLinuxDesktopExec(ucExePath, appid) {
   return `"${escapedExe}" --launch-appid=${safeAppid}`
 }
 
+/**
+ * Drain any queued one-shot navigation actions to the renderer once the
+ * window is ready. Used by `unioncrax://scan` to bounce the user straight
+ * to Settings → System Profile (with optional auto-scan).
+ */
+function drainNavigationActions() {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (pendingNavigationActions.length === 0) return
+  const deliver = () => {
+    while (pendingNavigationActions.length > 0) {
+      const next = pendingNavigationActions.shift()
+      try {
+        mainWindow.webContents.send('uc:navigation-action', next)
+        ucLog(`Delivered navigation action: ${next.action}`)
+      } catch (e) {
+        ucLog(`Failed to send navigation action: ${e?.message || e}`, 'warn')
+      }
+    }
+  }
+  if (mainWindow.webContents.isLoading()) {
+    mainWindow.webContents.once('did-finish-load', () => setTimeout(deliver, 0))
+  } else {
+    deliver()
+  }
+}
+
 async function processPendingAppLaunchRequests() {
   if (processingLaunchQueue) return
   if (!mainWindow || mainWindow.isDestroyed()) {
@@ -2406,11 +2490,22 @@ if (!gotTheLock) {
   if (initialLaunchRequest?.appid) {
     enqueueAppLaunchRequest(initialLaunchRequest.appid, initialLaunchRequest.source || 'initial-argv')
   }
+  const initialNavigationAction = parseNavigationActionFromArgv(process.argv)
+  if (initialNavigationAction) enqueueNavigationAction(initialNavigationAction)
 
   app.on('second-instance', (event, argv) => {
     const launchRequest = parseLaunchRequestFromArgv(argv)
     if (launchRequest?.appid) {
       enqueueAppLaunchRequest(launchRequest.appid, launchRequest.source || 'second-instance')
+    }
+    const navAction = parseNavigationActionFromArgv(argv)
+    if (navAction) {
+      enqueueNavigationAction(navAction)
+      // Fire-and-forget delivery: focusPrimaryWindow runs below and the
+      // renderer listener will drain the queue once the window is ready.
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        setTimeout(() => drainNavigationActions(), 50)
+      }
     }
 
     // Check if this second instance is from the setup/installer
@@ -7074,6 +7169,7 @@ function createWindow(existingSplash) {
   mainWindow.webContents.once('did-finish-load', () => {
     setTimeout(() => {
       void processPendingAppLaunchRequests()
+      drainNavigationActions()
     }, 0)
   })
 
@@ -7882,6 +7978,27 @@ ipcMain.handle('uc:logs-share', async (event, payload) => {
     const baseUrl = payload?.baseUrl || resolvedBaseUrl || DEFAULT_BASE_URL
     const rawLogs = getLogs()
     const logs = redactLogText(rawLogs || '')
+
+    // Optionally attach the user's hardware spec summary to the diagnostic
+    // report so the support team can see what they're running on. Opt-in
+    // via settings.attachSystemProfileToLogs (default: true — same as
+    // autoShareErrorLogs in spirit). PII-free: only the short summary string.
+    let systemSummary = null
+    let systemFingerprint = null
+    try {
+      const settings = readSettings() || {}
+      const attachEnabled = settings.attachSystemProfileToLogs !== false
+      if (attachEnabled) {
+        const cached = systemProfileScanner.readCachedProfile(app.getPath('userData'))
+        if (cached) {
+          systemSummary = systemProfileScanner.buildSummary(cached)
+          systemFingerprint = cached.fingerprint
+        }
+      }
+    } catch (e) {
+      ucLog(`[logs-share] system-profile attach skipped: ${e?.message || e}`, 'warn')
+    }
+
     const diagnosticsPayload = {
       source: 'unioncrax-direct',
       sessionId: LOG_SESSION_ID,
@@ -7893,6 +8010,8 @@ ipcMain.handle('uc:logs-share', async (event, payload) => {
         electron: process.versions.electron,
         node: process.versions.node,
       },
+      // Hardware context (opt-in, no full spec — just the summary line).
+      system: systemSummary ? { summary: systemSummary, fingerprint: systemFingerprint } : null,
       logs,
     }
 
@@ -8062,6 +8181,38 @@ ipcMain.handle('uc:download-start', (event, payload) => {
 
   const appid = payload.appid
   ucLog(`Download start: ${appid} (${payload.downloadId})`)
+
+  // Storage reservation: refuse to start the download if there isn't
+  // enough free space *after* accounting for download bytes + extraction
+  // overhead + any other in-flight reservations on the same drive.
+  // The renderer can bypass with payload.skipReservation=true (used by
+  // the resume-interrupted flow where the file is already on disk).
+  if (!payload.skipReservation) {
+    try {
+      const downloadRoot = ensureDownloadDir()
+      const expectedBytes = Number(payload.expectedSizeBytes) || Number(payload.totalBytes) || 0
+      const declaredInstallBytes = parseHumanSizeToBytes(payload.installedSize || payload.installSize) || 0
+      if (expectedBytes > 0) {
+        const check = storageReservation.reserve(payload.downloadId, {
+          targetPath: downloadRoot,
+          downloadBytes: expectedBytes,
+          declaredInstallBytes,
+        })
+        if (!check.ok) {
+          ucLog(`Download rejected — insufficient storage: ${appid} need=${check.requiredBytes} short=${check.shortfallBytes}`, 'warn')
+          return {
+            ok: false,
+            error: 'insufficient-storage',
+            storage: check,
+            message: `Not enough free space on the download drive. Need ~${formatBytesForHumans(check.requiredBytes)} (download + extract), only ~${formatBytesForHumans(check.availableAfterReservation)} available after other in-flight downloads.`,
+          }
+        }
+      }
+    } catch (err) {
+      ucLog(`Storage reservation precheck failed: ${err?.message || err}`, 'warn')
+    }
+  }
+
   if (hasAnyActiveOrPendingDownloads() || globalDownloadQueue.length > 0) {
     enqueueGlobalDownload(payload, win.webContents.id)
     ucLog(`Download queued: ${appid}`)
@@ -8093,6 +8244,7 @@ ipcMain.handle('uc:download-cancel', (_event, downloadId) => {
   cancelledDownloadIds.add(downloadId)
   // Auto-clean after 5 minutes to avoid memory leak
   setTimeout(() => cancelledDownloadIds.delete(downloadId), 5 * 60 * 1000)
+  try { storageReservation.release(downloadId) } catch { }
 
   // Helper: broadcast cancelled status so overlay/renderer remove the item
   const broadcastCancelled = () => {
@@ -11863,4 +12015,250 @@ ipcMain.handle('uc:system-notification-activated', async (_event, notificationId
   } catch (err) {
     return { ok: false, error: err.message }
   }
+})
+
+// ── System profile (UC ecosystem hardware scanner) ──────────────────────────
+
+let systemProfileScanInFlight = null
+
+ipcMain.handle('uc:system-profile-get-cached', () => {
+  try {
+    const cached = systemProfileScanner.readCachedProfile(app.getPath('userData'))
+    return { ok: true, profile: cached }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:system-profile-scan', async (_event, opts = {}) => {
+  const force = Boolean(opts?.force)
+  if (!force) {
+    const cached = systemProfileScanner.readCachedProfile(app.getPath('userData'))
+    if (cached?.spec) return { ok: true, profile: cached, cached: true }
+  }
+  // Deduplicate concurrent scans (UI may fire twice on click).
+  if (systemProfileScanInFlight) {
+    const profile = await systemProfileScanInFlight
+    return { ok: true, profile, cached: false }
+  }
+  systemProfileScanInFlight = (async () => {
+    try {
+      const profile = await systemProfileScanner.scanSystemProfile()
+      systemProfileScanner.writeCachedProfile(app.getPath('userData'), profile)
+      ucLog(`System profile scan complete (${profile.scanDurationMs}ms, fingerprint=${profile.fingerprint})`)
+      return profile
+    } finally {
+      systemProfileScanInFlight = null
+    }
+  })()
+  try {
+    const profile = await systemProfileScanInFlight
+    return { ok: true, profile, cached: false }
+  } catch (err) {
+    ucLog(`System profile scan failed: ${err?.message || err}`, 'error')
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:system-profile-summary', () => {
+  try {
+    const cached = systemProfileScanner.readCachedProfile(app.getPath('userData'))
+    if (!cached) return { ok: true, summary: null }
+    return { ok: true, summary: systemProfileScanner.buildSummary(cached), fingerprint: cached.fingerprint }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:system-profile-clear-cache', () => {
+  try {
+    const p = path.join(app.getPath('userData'), 'system-profile.json')
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+// Upload the locally-cached profile to the UC backend. Caller is responsible
+// for deciding *whether* to upload (i.e. visibility-gated in the renderer).
+ipcMain.handle('uc:system-profile-upload', async (event, { baseUrl } = {}) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) return { ok: false, error: 'no-window' }
+  try {
+    const cached = systemProfileScanner.readCachedProfile(app.getPath('userData'))
+    if (!cached) return { ok: false, error: 'no-profile' }
+    const settings = readSettings()
+    const deviceName = typeof settings?.systemProfileDeviceName === 'string' && settings.systemProfileDeviceName.trim()
+      ? settings.systemProfileDeviceName.trim()
+      : (require('os').hostname() || null)
+    const payload = {
+      version: cached.version,
+      fingerprint: cached.fingerprint,
+      capturedAt: cached.capturedAt,
+      sourceAppVersion: getAppVersion(),
+      deviceName,
+      spec: cached.spec,
+    }
+    const response = await fetchWithSession(win.webContents.session, baseUrl, '/api/profile/system', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    const body = await response.text()
+    let parsed = null
+    try { parsed = JSON.parse(body) } catch { /* swallow */ }
+    if (!response.ok) {
+      ucLog(`System profile upload failed: ${response.status} ${body.slice(0, 200)}`, 'warn')
+      return { ok: false, status: response.status, error: parsed?.error || `HTTP ${response.status}` }
+    }
+    return { ok: true, fingerprint: parsed?.fingerprint, summary: parsed?.summary }
+  } catch (err) {
+    ucLog(`System profile upload error: ${err?.message || err}`, 'error')
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+// Server-side visibility get/set (mirrors local settings but stored on server).
+ipcMain.handle('uc:system-profile-server-visibility-get', async (event, { baseUrl } = {}) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) return { ok: false, error: 'no-window' }
+  try {
+    const response = await fetchWithSession(win.webContents.session, baseUrl, '/api/profile/system/visibility', {
+      method: 'GET',
+    })
+    if (!response.ok) return { ok: false, status: response.status }
+    const data = await response.json()
+    return { ok: true, visibility: data?.visibility || null }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:system-profile-server-visibility-set', async (event, { baseUrl, patch } = {}) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) return { ok: false, error: 'no-window' }
+  try {
+    const response = await fetchWithSession(win.webContents.session, baseUrl, '/api/profile/system/visibility', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch || {}),
+    })
+    if (!response.ok) return { ok: false, status: response.status }
+    const data = await response.json()
+    return { ok: true, visibility: data?.visibility || null }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+// Delete the server-side profile (used when user clears specs locally).
+ipcMain.handle('uc:system-profile-server-delete', async (event, { baseUrl } = {}) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  if (!win || win.isDestroyed()) return { ok: false, error: 'no-window' }
+  try {
+    const response = await fetchWithSession(win.webContents.session, baseUrl, '/api/profile/system', {
+      method: 'DELETE',
+    })
+    return { ok: response.ok, status: response.status }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+// ── Multi-rig device list ──
+async function passthroughJson(sender, baseUrl, path, init) {
+  const win = BrowserWindow.fromWebContents(sender)
+  if (!win || win.isDestroyed()) return { ok: false, error: 'no-window' }
+  try {
+    const response = await fetchWithSession(win.webContents.session, baseUrl, path, init)
+    const text = await response.text()
+    let parsed = null
+    try { parsed = JSON.parse(text) } catch { /* swallow */ }
+    if (!response.ok) {
+      return { ok: false, status: response.status, error: parsed?.error || `HTTP ${response.status}` }
+    }
+    return { ok: true, status: response.status, ...(parsed || {}) }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+}
+
+ipcMain.handle('uc:system-profile-list-devices', (event, { baseUrl } = {}) =>
+  passthroughJson(event.sender, baseUrl, '/api/profile/system/devices', { method: 'GET' })
+)
+
+ipcMain.handle('uc:system-profile-rename-device', (event, { baseUrl, fingerprint, name } = {}) =>
+  passthroughJson(event.sender, baseUrl, `/api/profile/system/devices/${encodeURIComponent(String(fingerprint || ''))}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ deviceName: name || null }),
+  })
+)
+
+ipcMain.handle('uc:system-profile-delete-device', (event, { baseUrl, fingerprint } = {}) =>
+  passthroughJson(event.sender, baseUrl, `/api/profile/system/devices/${encodeURIComponent(String(fingerprint || ''))}`, {
+    method: 'DELETE',
+  })
+)
+
+ipcMain.handle('uc:system-profile-activate-device', (event, { baseUrl, fingerprint } = {}) =>
+  passthroughJson(event.sender, baseUrl, `/api/profile/system/devices/${encodeURIComponent(String(fingerprint || ''))}/activate`, {
+    method: 'POST',
+  })
+)
+
+// ── Share-a-spec links ──
+ipcMain.handle('uc:system-profile-list-shares', (event, { baseUrl } = {}) =>
+  passthroughJson(event.sender, baseUrl, '/api/profile/system/share', { method: 'GET' })
+)
+
+ipcMain.handle('uc:system-profile-create-share', (event, { baseUrl, opts } = {}) =>
+  passthroughJson(event.sender, baseUrl, '/api/profile/system/share', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(opts || {}),
+  })
+)
+
+ipcMain.handle('uc:system-profile-revoke-share', (event, { baseUrl, shortCode } = {}) =>
+  passthroughJson(event.sender, baseUrl, `/api/profile/system/share/${encodeURIComponent(String(shortCode || ''))}`, {
+    method: 'DELETE',
+  })
+)
+
+// Upgrade suggester — compares wishlist vs active profile.
+ipcMain.handle('uc:system-profile-upgrade-suggest', (event, { baseUrl } = {}) =>
+  passthroughJson(event.sender, baseUrl, '/api/profile/system/upgrade-suggest', { method: 'GET' })
+)
+
+// ── Storage reservation (used by sysreq UI + concurrency safety) ────────────
+
+ipcMain.handle('uc:storage-precheck', (_event, opts) => {
+  try {
+    const downloadRoot = ensureDownloadDir()
+    const result = storageReservation.precheck({
+      targetPath: opts?.targetPath || downloadRoot,
+      downloadBytes: Number(opts?.downloadBytes) || 0,
+      declaredInstallBytes: Number(opts?.declaredInstallBytes) || 0,
+    })
+    return { ok: true, ...result, humanRequired: formatBytesForHumans(result.requiredBytes), humanFree: formatBytesForHumans(result.freeBytes), humanShortfall: formatBytesForHumans(result.shortfallBytes), humanAvailable: formatBytesForHumans(result.availableAfterReservation) }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:storage-summary', (_event, targetPath) => {
+  try {
+    const downloadRoot = targetPath || ensureDownloadDir()
+    const summary = storageReservation.summaryForPath(downloadRoot)
+    return { ok: true, ...summary, humanFree: formatBytesForHumans(summary.freeBytes), humanReserved: formatBytesForHumans(summary.reservedBytes), humanAvailable: formatBytesForHumans(summary.availableBytes) }
+  } catch (err) {
+    return { ok: false, error: err?.message || String(err) }
+  }
+})
+
+ipcMain.handle('uc:storage-snapshot', () => {
+  try { return { ok: true, reservations: storageReservation.snapshot() } }
+  catch (err) { return { ok: false, error: err?.message || String(err) } }
 })

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -95,6 +95,12 @@ contextBridge.exposeInMainWorld('ucApp', {
     const listener = (_event, data) => callback(data)
     ipcRenderer.on('uc:app-close-requested', listener)
     return () => ipcRenderer.removeListener('uc:app-close-requested', listener)
+  },
+  // One-shot navigation actions from deep links (e.g. unioncrax://scan).
+  onNavigationAction: (callback) => {
+    const listener = (_event, data) => callback(data)
+    ipcRenderer.on('uc:navigation-action', listener)
+    return () => ipcRenderer.removeListener('uc:navigation-action', listener)
   }
 })
 
@@ -300,6 +306,35 @@ contextBridge.exposeInMainWorld('ucController', {
   // Overlay-specific
   getOverlaySettings: () => ipcRenderer.invoke('uc:controller-get-overlay-settings'),
   setOverlaySettings: (settings) => ipcRenderer.invoke('uc:controller-set-overlay-settings', settings),
+})
+
+// System hardware profile (UC ecosystem scanner)
+contextBridge.exposeInMainWorld('ucSystemProfile', {
+  getCached: () => ipcRenderer.invoke('uc:system-profile-get-cached'),
+  scan: (opts) => ipcRenderer.invoke('uc:system-profile-scan', opts || {}),
+  summary: () => ipcRenderer.invoke('uc:system-profile-summary'),
+  clearCache: () => ipcRenderer.invoke('uc:system-profile-clear-cache'),
+  // Server-sync (visibility-gated; renderer decides when to call)
+  upload: (baseUrl) => ipcRenderer.invoke('uc:system-profile-upload', { baseUrl }),
+  serverGetVisibility: (baseUrl) => ipcRenderer.invoke('uc:system-profile-server-visibility-get', { baseUrl }),
+  serverSetVisibility: (baseUrl, patch) => ipcRenderer.invoke('uc:system-profile-server-visibility-set', { baseUrl, patch }),
+  serverDelete: (baseUrl) => ipcRenderer.invoke('uc:system-profile-server-delete', { baseUrl }),
+  // Multi-rig + share-a-spec
+  listDevices: (baseUrl) => ipcRenderer.invoke('uc:system-profile-list-devices', { baseUrl }),
+  renameDevice: (baseUrl, fingerprint, name) => ipcRenderer.invoke('uc:system-profile-rename-device', { baseUrl, fingerprint, name }),
+  deleteDevice: (baseUrl, fingerprint) => ipcRenderer.invoke('uc:system-profile-delete-device', { baseUrl, fingerprint }),
+  activateDevice: (baseUrl, fingerprint) => ipcRenderer.invoke('uc:system-profile-activate-device', { baseUrl, fingerprint }),
+  listShares: (baseUrl) => ipcRenderer.invoke('uc:system-profile-list-shares', { baseUrl }),
+  createShare: (baseUrl, opts) => ipcRenderer.invoke('uc:system-profile-create-share', { baseUrl, opts }),
+  revokeShare: (baseUrl, shortCode) => ipcRenderer.invoke('uc:system-profile-revoke-share', { baseUrl, shortCode }),
+  upgradeSuggest: (baseUrl) => ipcRenderer.invoke('uc:system-profile-upgrade-suggest', { baseUrl }),
+})
+
+// Storage reservation API (pre-download space checks)
+contextBridge.exposeInMainWorld('ucStorage', {
+  precheck: (opts) => ipcRenderer.invoke('uc:storage-precheck', opts),
+  summary: (targetPath) => ipcRenderer.invoke('uc:storage-summary', targetPath),
+  snapshot: () => ipcRenderer.invoke('uc:storage-snapshot'),
 })
 
 // System API (volume, screenshot, notifications, openExternal)

--- a/electron/storage-reservation.cjs
+++ b/electron/storage-reservation.cjs
@@ -1,0 +1,194 @@
+// Storage reservation for concurrent downloads + extraction.
+//
+// A "reservation" represents bytes UC.D has committed to keep available
+// for an in-flight download or extraction. Because we always extract the
+// archive into the same drive after download completes, each reservation
+// carries TWO numbers: downloadBytes (archive on disk) and extractBytes
+// (extracted game). The total reserved equals their sum until the
+// download finishes; once the archive is deleted post-extraction, the
+// caller calls releaseDownload() so only extractBytes remains held; then
+// the install completion calls release() to drop the whole reservation.
+//
+// Reservations are per-mount, identified by the drive root that contains
+// the target path. We snapshot disk free space at reserve time and never
+// trust subsequent fs.statfsSync(): freeBytes - reserved is what's
+// actually available to a new download.
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const DEFAULT_EXTRACTION_RATIO = 2.0   // extracted ≈ archive * 2 unless metadata says otherwise
+const DEFAULT_SAFETY_BUFFER = 2 * 1024 ** 3 // 2 GiB headroom on top of the estimate
+const SAFETY_BUFFER_RATIO = 0.05       // or 5% of estimate, whichever is larger
+
+const reservations = new Map() // id -> { mountRoot, downloadBytes, extractBytes, status }
+
+function getMountRoot(targetPath) {
+  if (!targetPath) return null
+  if (process.platform === 'win32') {
+    // C:\foo\bar -> C:\
+    const match = String(targetPath).match(/^([A-Za-z]):/)
+    return match ? `${match[1].toUpperCase()}:\\` : null
+  }
+  // POSIX: walk up until we find an existing parent. We'll use the
+  // top-level filesystem boundary later via statfs, but for keying we
+  // just normalize the absolute path's first segment.
+  const abs = path.resolve(targetPath)
+  return '/' // single-root reservation keying on Linux is fine for our use
+}
+
+function getFreeBytesAtPath(targetPath) {
+  try {
+    let current = targetPath
+    while (current && !fs.existsSync(current)) {
+      const parent = path.dirname(current)
+      if (!parent || parent === current) return null
+      current = parent
+    }
+    if (!current) return null
+    const st = fs.statfsSync(current)
+    return st.bavail * st.bsize
+  } catch {
+    return null
+  }
+}
+
+function sumActiveReservations(mountRoot, excludeId = null) {
+  let download = 0
+  let extract = 0
+  for (const [id, r] of reservations) {
+    if (id === excludeId) continue
+    if (r.mountRoot !== mountRoot) continue
+    if (r.status === 'released') continue
+    if (r.status !== 'extracting') download += r.downloadBytes || 0
+    extract += r.extractBytes || 0
+  }
+  return { download, extract, total: download + extract }
+}
+
+function estimateExtractionBytes(downloadBytes, declaredInstallBytes) {
+  // Prefer the declared installed size from the game's metadata when we
+  // trust it; otherwise assume 2x the archive — that's the worst common
+  // case for 7z/zip archives of games and what we already use elsewhere.
+  const fromDeclared = Number(declaredInstallBytes) || 0
+  const fromArchive = Math.round((Number(downloadBytes) || 0) * DEFAULT_EXTRACTION_RATIO)
+  const estimate = Math.max(fromDeclared, fromArchive)
+  const buffer = Math.max(DEFAULT_SAFETY_BUFFER, Math.round(estimate * SAFETY_BUFFER_RATIO))
+  return estimate + buffer
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.targetPath   Where the archive will be written
+ * @param {number} opts.downloadBytes Expected archive size in bytes (best estimate)
+ * @param {number} [opts.declaredInstallBytes] Optional installed size from game metadata
+ * @returns {{ ok: boolean, requiredBytes: number, freeBytes: number, shortfallBytes: number,
+ *            downloadBytes: number, extractBytes: number, alreadyReservedBytes: number,
+ *            availableAfterReservation: number, mountRoot: string|null }}
+ */
+function precheck({ targetPath, downloadBytes, declaredInstallBytes }) {
+  const mountRoot = getMountRoot(targetPath)
+  const freeBytes = getFreeBytesAtPath(targetPath) || 0
+  const extractBytes = estimateExtractionBytes(downloadBytes, declaredInstallBytes)
+  const requiredBytes = (Number(downloadBytes) || 0) + extractBytes
+  const existing = sumActiveReservations(mountRoot)
+  const availableAfterReservation = freeBytes - existing.total
+  const shortfallBytes = Math.max(0, requiredBytes - availableAfterReservation)
+  return {
+    ok: shortfallBytes === 0,
+    requiredBytes,
+    freeBytes,
+    shortfallBytes,
+    downloadBytes: Number(downloadBytes) || 0,
+    extractBytes,
+    alreadyReservedBytes: existing.total,
+    availableAfterReservation,
+    mountRoot,
+  }
+}
+
+/**
+ * Commit a reservation. Caller passes the same id (typically downloadId
+ * or appid+version) for later transitions/release. Returns the same
+ * check shape as precheck() but with ok=false if the reservation could
+ * not be honored.
+ */
+function reserve(id, opts) {
+  if (!id) throw new Error('reserve requires an id')
+  if (reservations.has(id)) {
+    // Idempotent: return the existing reservation summary.
+    const existing = reservations.get(id)
+    return {
+      ok: true,
+      already: true,
+      requiredBytes: (existing.downloadBytes || 0) + (existing.extractBytes || 0),
+      downloadBytes: existing.downloadBytes,
+      extractBytes: existing.extractBytes,
+      mountRoot: existing.mountRoot,
+      freeBytes: getFreeBytesAtPath(opts.targetPath) || 0,
+      shortfallBytes: 0,
+      alreadyReservedBytes: sumActiveReservations(existing.mountRoot, id).total,
+      availableAfterReservation: (getFreeBytesAtPath(opts.targetPath) || 0) - sumActiveReservations(existing.mountRoot, id).total,
+    }
+  }
+  const check = precheck(opts)
+  if (!check.ok) return { ...check, ok: false }
+  reservations.set(id, {
+    mountRoot: check.mountRoot,
+    downloadBytes: check.downloadBytes,
+    extractBytes: check.extractBytes,
+    status: 'downloading',
+    createdAt: Date.now(),
+  })
+  return { ...check, ok: true }
+}
+
+/** Transition: download is complete, extraction has started. Free the
+ *  archive bytes (they'll be reused by the extracted output) but keep
+ *  the extract bytes pinned. */
+function markExtracting(id) {
+  const r = reservations.get(id)
+  if (!r) return false
+  r.status = 'extracting'
+  return true
+}
+
+/** Drop the entire reservation (download complete + archive deleted, or
+ *  cancelled, or errored). */
+function release(id) {
+  return reservations.delete(id)
+}
+
+function get(id) {
+  return reservations.get(id) || null
+}
+
+function snapshot() {
+  return [...reservations.entries()].map(([id, r]) => ({ id, ...r }))
+}
+
+function summaryForPath(targetPath) {
+  const mountRoot = getMountRoot(targetPath)
+  const freeBytes = getFreeBytesAtPath(targetPath) || 0
+  const existing = sumActiveReservations(mountRoot)
+  return {
+    mountRoot,
+    freeBytes,
+    reservedBytes: existing.total,
+    reservedDownloadBytes: existing.download,
+    reservedExtractBytes: existing.extract,
+    availableBytes: freeBytes - existing.total,
+  }
+}
+
+module.exports = {
+  precheck,
+  reserve,
+  markExtracting,
+  release,
+  get,
+  snapshot,
+  summaryForPath,
+  estimateExtractionBytes,
+  getMountRoot,
+}

--- a/electron/system-profile.cjs
+++ b/electron/system-profile.cjs
@@ -1,0 +1,523 @@
+// UC System Profile scanner.
+//
+// Collects a canonical hardware/OS spec for the local machine using only
+// platform-native tools (no npm deps, no native rebuilds). The result is
+// cached to userData and uploaded by the renderer to the UC backend when
+// the user opts in. Shape is versioned via SPEC_VERSION so old snapshots
+// stored against posts remain interpretable after we extend the scanner.
+
+const os = require('node:os')
+const fs = require('node:fs')
+const path = require('node:path')
+const crypto = require('node:crypto')
+const child_process = require('node:child_process')
+
+const SPEC_VERSION = 1
+
+// PowerShell on Windows can be slow on cold starts; give each probe a
+// generous budget but never block forever.
+const WIN_PS_TIMEOUT_MS = 8000
+const NIX_CMD_TIMEOUT_MS = 4000
+
+function runCommand(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    let stdout = ''
+    let stderr = ''
+    let done = false
+    let proc
+    try {
+      proc = child_process.spawn(cmd, args, { windowsHide: true, ...opts })
+    } catch (err) {
+      resolve({ ok: false, stdout: '', stderr: String(err?.message || err), code: -1 })
+      return
+    }
+    const timeout = setTimeout(() => {
+      if (done) return
+      done = true
+      try { proc.kill() } catch {}
+      resolve({ ok: false, stdout, stderr: stderr + '\n[timeout]', code: -1 })
+    }, opts.timeoutMs || NIX_CMD_TIMEOUT_MS)
+    proc.stdout?.on('data', (d) => { stdout += d.toString() })
+    proc.stderr?.on('data', (d) => { stderr += d.toString() })
+    proc.on('error', (err) => {
+      if (done) return
+      done = true
+      clearTimeout(timeout)
+      resolve({ ok: false, stdout, stderr: String(err?.message || err), code: -1 })
+    })
+    proc.on('close', (code) => {
+      if (done) return
+      done = true
+      clearTimeout(timeout)
+      resolve({ ok: code === 0, stdout, stderr, code })
+    })
+  })
+}
+
+async function runPS(script) {
+  // -NoProfile keeps cold start fast; ConvertTo-Json gives us structured output.
+  return runCommand('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+    timeoutMs: WIN_PS_TIMEOUT_MS,
+  })
+}
+
+function safeJsonParse(text) {
+  if (!text) return null
+  try { return JSON.parse(text) } catch { return null }
+}
+
+function toArray(value) {
+  if (value == null) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+function readFileSafe(p) {
+  try { return fs.readFileSync(p, 'utf8') } catch { return null }
+}
+
+// ── Windows probes ──────────────────────────────────────────────────────────
+
+async function scanWindows() {
+  const script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$cs   = Get-CimInstance Win32_ComputerSystem
+$os_  = Get-CimInstance Win32_OperatingSystem
+$cpu  = Get-CimInstance Win32_Processor | Select-Object Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed,Manufacturer,Architecture
+$gpu  = Get-CimInstance Win32_VideoController | Select-Object Name,AdapterRAM,DriverVersion,DriverDate,VideoProcessor
+$mem  = Get-CimInstance Win32_PhysicalMemory | Select-Object Capacity,Speed,ConfiguredClockSpeed,Manufacturer,PartNumber
+$disk = Get-CimInstance Win32_DiskDrive | Select-Object Model,Size,MediaType,InterfaceType
+$vol  = Get-CimInstance Win32_LogicalDisk -Filter 'DriveType=3' | Select-Object DeviceID,Size,FreeSpace,FileSystem
+# Storage-Spaces-aware drive-letter → physical-media map. Storage cmdlets are
+# present on Win8+; we ignore failures so older systems still produce a result.
+$volMedia = @()
+try {
+  $volMedia = Get-Partition -ErrorAction SilentlyContinue | Where-Object { $_.DriveLetter } | ForEach-Object {
+    $disk = $_ | Get-Disk -ErrorAction SilentlyContinue
+    $pdisk = $null
+    if ($disk) { $pdisk = $disk | Get-PhysicalDisk -ErrorAction SilentlyContinue }
+    @{
+      Letter    = "$($_.DriveLetter):"
+      MediaType = if ($pdisk) { $pdisk.MediaType } else { $null }
+      BusType   = if ($pdisk) { $pdisk.BusType }   else { $null }
+    }
+  }
+} catch { }
+$mon  = Get-CimInstance Win32_VideoController | ForEach-Object { @{ Name=$_.Name; HRes=$_.CurrentHorizontalResolution; VRes=$_.CurrentVerticalResolution; Refresh=$_.CurrentRefreshRate } }
+$out = @{
+  cs=$cs; os=$os_; cpu=$cpu; gpu=$gpu; mem=$mem; disk=$disk; vol=$vol; display=$mon; volMedia=$volMedia
+}
+$out | ConvertTo-Json -Depth 5 -Compress
+`
+  const result = await runPS(script)
+  const parsed = safeJsonParse(result.stdout) || {}
+
+  const cpus = toArray(parsed.cpu)
+  const cpu = cpus[0] || {}
+  const archMap = { 0: 'x86', 5: 'arm', 6: 'ia64', 9: 'x64', 12: 'arm64' }
+
+  const gpus = toArray(parsed.gpu).map((g) => ({
+    name: g?.Name || null,
+    vramBytes: Number(g?.AdapterRAM) || null,
+    vendor: detectGpuVendor(g?.Name || ''),
+    driverVersion: g?.DriverVersion || null,
+    driverDate: g?.DriverDate || null,
+    videoProcessor: g?.VideoProcessor || null,
+  }))
+
+  const memModules = toArray(parsed.mem)
+  const ramTotalBytes = memModules.reduce((sum, m) => sum + (Number(m?.Capacity) || 0), 0)
+    || (Number(parsed.cs?.TotalPhysicalMemory) || os.totalmem() || 0)
+  const ramSpeedMhz = memModules.length
+    ? Math.max(...memModules.map((m) => Number(m?.ConfiguredClockSpeed) || Number(m?.Speed) || 0))
+    : null
+
+  const drives = toArray(parsed.disk).map((d) => ({
+    model: d?.Model || null,
+    sizeBytes: Number(d?.Size) || null,
+    mediaType: normalizeWindowsMediaType(d?.MediaType, d?.Model),
+    interfaceType: d?.InterfaceType || null,
+  }))
+
+  const volMediaMap = new Map()
+  for (const entry of toArray(parsed.volMedia)) {
+    if (entry?.Letter) volMediaMap.set(String(entry.Letter).toUpperCase(), {
+      mediaType: normalizeStorageMediaType(entry.MediaType),
+      busType: entry.BusType || null,
+    })
+  }
+
+  const volumes = toArray(parsed.vol).map((v) => {
+    const mount = v?.DeviceID || null
+    const mapped = mount ? volMediaMap.get(String(mount).toUpperCase()) : null
+    return {
+      mount,
+      sizeBytes: Number(v?.Size) || null,
+      freeBytes: Number(v?.FreeSpace) || null,
+      fs: v?.FileSystem || null,
+      mediaType: mapped?.mediaType ?? null,
+      busType: mapped?.busType ?? null,
+    }
+  })
+
+  const displays = toArray(parsed.display)
+    .filter((d) => d?.HRes && d?.VRes)
+    .map((d) => ({
+      label: d?.Name || null,
+      width: Number(d.HRes) || null,
+      height: Number(d.VRes) || null,
+      refreshHz: Number(d.Refresh) || null,
+    }))
+
+  return {
+    cpu: {
+      model: cpu.Name?.trim() || null,
+      vendor: cpu.Manufacturer || null,
+      arch: archMap[Number(cpu.Architecture)] || os.arch(),
+      cores: Number(cpu.NumberOfCores) || null,
+      threads: Number(cpu.NumberOfLogicalProcessors) || null,
+      baseClockMhz: Number(cpu.MaxClockSpeed) || null,
+    },
+    gpus,
+    ram: {
+      totalBytes: ramTotalBytes,
+      modules: memModules.length,
+      speedMhz: ramSpeedMhz,
+      channels: inferRamChannels(memModules.length),
+    },
+    storage: { drives, volumes },
+    os: {
+      platform: 'win32',
+      name: parsed.os?.Caption?.trim() || 'Windows',
+      version: parsed.os?.Version || os.release(),
+      build: parsed.os?.BuildNumber || null,
+      arch: parsed.os?.OSArchitecture || os.arch(),
+      locale: parsed.os?.OSLanguage ? String(parsed.os.OSLanguage) : null,
+    },
+    displays,
+    graphics: await detectGraphicsApisWindows(),
+  }
+}
+
+/**
+ * Map the value returned by Storage Spaces' Get-PhysicalDisk into our
+ * canonical `'nvme' | 'ssd' | 'hdd' | 'unspecified' | null` tagging.
+ * Get-PhysicalDisk's MediaType property uses numeric codes (3=HDD, 4=SSD,
+ * 5=SCM) or strings depending on Windows version, so we accept both.
+ */
+function normalizeStorageMediaType(value) {
+  if (value == null) return null
+  const text = String(value).toLowerCase()
+  if (text.includes('nvme')) return 'nvme'
+  if (text === 'ssd' || text === '4' || text.includes('solid state')) return 'ssd'
+  if (text === 'hdd' || text === '3' || text.includes('hard disk') || text.includes('rotational')) return 'hdd'
+  if (text === '5' || text === 'scm') return 'scm'
+  if (text === '0' || text === 'unspecified') return null
+  return null
+}
+
+function normalizeWindowsMediaType(media, model) {
+  const text = `${media || ''} ${model || ''}`.toLowerCase()
+  if (text.includes('nvme')) return 'nvme'
+  if (text.includes('ssd') || text.includes('solid state')) return 'ssd'
+  if (text.includes('hdd') || text.includes('hard disk') || text.includes('fixed hard')) return 'hdd'
+  if (text.includes('removable')) return 'removable'
+  return media || null
+}
+
+async function detectGraphicsApisWindows() {
+  // dxdiag is the canonical source but is slow (~2-4s) and writes to a file.
+  // We probe the cheap, common API versions: DX12 presence is implicit on
+  // Win10+, Vulkan via the vulkaninfo binary if installed.
+  const dx = process.platform === 'win32' ? '12' : null
+  const vk = await runCommand('vulkaninfo', ['--summary'], { timeoutMs: 3000 })
+  let vulkanVersion = null
+  if (vk.ok) {
+    const m = vk.stdout.match(/Vulkan Instance Version:\s*([\d.]+)/i)
+    vulkanVersion = m ? m[1] : null
+  }
+  return {
+    directx: dx,
+    vulkan: vulkanVersion,
+    opengl: null,
+  }
+}
+
+// ── Linux probes ────────────────────────────────────────────────────────────
+
+async function scanLinux() {
+  const [cpuInfo, memInfo, gpus, drives, displays, vkVersion, glVersion, distro] = await Promise.all([
+    probeLinuxCpu(),
+    probeLinuxMemory(),
+    probeLinuxGpus(),
+    probeLinuxDrives(),
+    probeLinuxDisplays(),
+    probeLinuxVulkan(),
+    probeLinuxOpenGL(),
+    probeLinuxDistro(),
+  ])
+
+  return {
+    cpu: cpuInfo,
+    gpus,
+    ram: memInfo,
+    storage: { drives, volumes: probeLinuxVolumes() },
+    os: {
+      platform: 'linux',
+      name: distro.name || 'Linux',
+      version: distro.version || os.release(),
+      build: os.release(),
+      arch: os.arch(),
+      locale: process.env.LANG || null,
+    },
+    displays,
+    graphics: {
+      directx: null,
+      vulkan: vkVersion,
+      opengl: glVersion,
+    },
+  }
+}
+
+async function probeLinuxCpu() {
+  const cpuinfo = readFileSafe('/proc/cpuinfo') || ''
+  const modelLine = cpuinfo.match(/^model name\s*:\s*(.+)$/m)
+  const vendorLine = cpuinfo.match(/^vendor_id\s*:\s*(.+)$/m)
+  const cpuCount = os.cpus().length
+  let cores = null
+  const cpuCoresLine = cpuinfo.match(/^cpu cores\s*:\s*(\d+)$/m)
+  if (cpuCoresLine) cores = Number(cpuCoresLine[1])
+  const baseClock = os.cpus()[0]?.speed || null
+  return {
+    model: modelLine ? modelLine[1].trim() : null,
+    vendor: vendorLine ? vendorLine[1].trim() : null,
+    arch: os.arch(),
+    cores,
+    threads: cpuCount,
+    baseClockMhz: baseClock,
+  }
+}
+
+async function probeLinuxMemory() {
+  const meminfo = readFileSafe('/proc/meminfo') || ''
+  const totalKb = Number((meminfo.match(/MemTotal:\s+(\d+)/) || [])[1] || 0)
+  return {
+    totalBytes: totalKb ? totalKb * 1024 : (os.totalmem() || 0),
+    modules: null,
+    speedMhz: null,
+    channels: null,
+  }
+}
+
+async function probeLinuxGpus() {
+  const lspci = await runCommand('lspci', ['-mm'], {})
+  if (!lspci.ok) return []
+  const lines = lspci.stdout.split('\n')
+  const gpus = []
+  for (const line of lines) {
+    if (!/VGA|3D|Display/i.test(line)) continue
+    // Format: "00:02.0 "VGA compatible controller" "Intel Corporation" "Device Name" ...
+    const parts = line.match(/"([^"]*)"/g)?.map((s) => s.slice(1, -1)) || []
+    const vendor = parts[1] || null
+    const name = parts[2] || null
+    if (!name) continue
+    gpus.push({
+      name,
+      vendor: detectGpuVendor(`${vendor} ${name}`),
+      vramBytes: null,
+      driverVersion: null,
+      driverDate: null,
+    })
+  }
+  return gpus
+}
+
+async function probeLinuxDrives() {
+  const lsblk = await runCommand('lsblk', ['-bdJ', '-o', 'NAME,SIZE,ROTA,TYPE,MODEL,TRAN'], {})
+  if (!lsblk.ok) return []
+  const parsed = safeJsonParse(lsblk.stdout)
+  if (!parsed?.blockdevices) return []
+  return parsed.blockdevices
+    .filter((d) => d.type === 'disk')
+    .map((d) => ({
+      model: d.model || null,
+      sizeBytes: Number(d.size) || null,
+      mediaType: d.tran === 'nvme' ? 'nvme' : (d.rota === '0' || d.rota === false) ? 'ssd' : 'hdd',
+      interfaceType: d.tran || null,
+    }))
+}
+
+function probeLinuxVolumes() {
+  // statfs each mount we know about; cheap enough.
+  const mounts = readFileSafe('/proc/mounts') || ''
+  const seen = new Set()
+  const out = []
+  for (const line of mounts.split('\n')) {
+    const parts = line.split(/\s+/)
+    const mount = parts[1]
+    const fsType = parts[2]
+    if (!mount || seen.has(mount)) continue
+    if (!/^(ext|xfs|btrfs|f2fs|zfs|ntfs|vfat|exfat)/i.test(fsType || '')) continue
+    seen.add(mount)
+    try {
+      const st = fs.statfsSync(mount)
+      out.push({
+        mount,
+        sizeBytes: st.blocks * st.bsize,
+        freeBytes: st.bavail * st.bsize,
+        fs: fsType,
+      })
+    } catch {}
+    if (out.length >= 16) break
+  }
+  return out
+}
+
+async function probeLinuxDisplays() {
+  const xrandr = await runCommand('xrandr', ['--current'], { timeoutMs: 2000 })
+  if (!xrandr.ok) return []
+  const displays = []
+  for (const line of xrandr.stdout.split('\n')) {
+    const m = line.match(/^\s*(\d+)x(\d+)\s+([\d.]+)\*/)
+    if (m) {
+      displays.push({
+        label: null,
+        width: Number(m[1]),
+        height: Number(m[2]),
+        refreshHz: Math.round(Number(m[3])),
+      })
+    }
+  }
+  return displays
+}
+
+async function probeLinuxVulkan() {
+  const vk = await runCommand('vulkaninfo', ['--summary'], { timeoutMs: 3000 })
+  if (!vk.ok) return null
+  const m = vk.stdout.match(/Vulkan Instance Version:\s*([\d.]+)/i)
+  return m ? m[1] : null
+}
+
+async function probeLinuxOpenGL() {
+  const gl = await runCommand('glxinfo', ['-B'], { timeoutMs: 3000 })
+  if (!gl.ok) return null
+  const m = gl.stdout.match(/OpenGL version string:\s*([^\n]+)/i)
+  return m ? m[1].trim() : null
+}
+
+async function probeLinuxDistro() {
+  const osRelease = readFileSafe('/etc/os-release') || ''
+  const name = (osRelease.match(/^PRETTY_NAME="?([^"\n]+)"?/m) || [])[1] || null
+  const version = (osRelease.match(/^VERSION_ID="?([^"\n]+)"?/m) || [])[1] || null
+  return { name, version }
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+function detectGpuVendor(name) {
+  const lower = (name || '').toLowerCase()
+  if (lower.includes('nvidia') || lower.includes('geforce') || lower.includes('quadro') || lower.includes('rtx') || lower.includes('gtx')) return 'nvidia'
+  if (lower.includes('amd') || lower.includes('radeon') || lower.includes('ati')) return 'amd'
+  if (lower.includes('intel') || lower.includes('arc ') || lower.includes('iris') || lower.includes('uhd')) return 'intel'
+  if (lower.includes('apple')) return 'apple'
+  return 'unknown'
+}
+
+function inferRamChannels(moduleCount) {
+  if (!moduleCount) return null
+  if (moduleCount === 1) return 'single'
+  if (moduleCount === 2) return 'dual'
+  if (moduleCount === 4) return 'quad'
+  return `${moduleCount}-module`
+}
+
+function computeFingerprint(spec) {
+  // Hash the *structurally meaningful* parts of the spec — anything whose
+  // change should trigger a "PC has changed, rescan?" prompt. Driver/free-
+  // space changes don't count.
+  const stable = {
+    cpu: spec?.cpu?.model || null,
+    cores: spec?.cpu?.cores || null,
+    gpus: (spec?.gpus || []).map((g) => g.name).sort(),
+    ramTotal: roundToGib(spec?.ram?.totalBytes),
+    drives: (spec?.storage?.drives || []).map((d) => `${d.model}|${d.mediaType}|${roundToGib(d.sizeBytes)}`).sort(),
+    osName: spec?.os?.name || null,
+  }
+  return crypto.createHash('sha256').update(JSON.stringify(stable)).digest('hex').slice(0, 16)
+}
+
+function roundToGib(bytes) {
+  if (!bytes) return 0
+  return Math.round(bytes / (1024 ** 3))
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+async function scanSystemProfile() {
+  const startedAt = Date.now()
+  let spec
+  if (process.platform === 'win32') {
+    spec = await scanWindows()
+  } else if (process.platform === 'linux') {
+    spec = await scanLinux()
+  } else {
+    // macOS or other — minimal fallback from Node built-ins.
+    spec = {
+      cpu: { model: os.cpus()[0]?.model || null, vendor: null, arch: os.arch(), cores: null, threads: os.cpus().length, baseClockMhz: os.cpus()[0]?.speed || null },
+      gpus: [],
+      ram: { totalBytes: os.totalmem(), modules: null, speedMhz: null, channels: null },
+      storage: { drives: [], volumes: [] },
+      os: { platform: process.platform, name: os.type(), version: os.release(), build: null, arch: os.arch(), locale: null },
+      displays: [],
+      graphics: { directx: null, vulkan: null, opengl: null },
+    }
+  }
+  return {
+    version: SPEC_VERSION,
+    capturedAt: new Date().toISOString(),
+    scanDurationMs: Date.now() - startedAt,
+    fingerprint: computeFingerprint(spec),
+    spec,
+  }
+}
+
+function getCachePath(userDataDir) {
+  return path.join(userDataDir, 'system-profile.json')
+}
+
+function readCachedProfile(userDataDir) {
+  try {
+    const raw = fs.readFileSync(getCachePath(userDataDir), 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function writeCachedProfile(userDataDir, profile) {
+  try {
+    fs.writeFileSync(getCachePath(userDataDir), JSON.stringify(profile, null, 2), 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function buildSummary(profile) {
+  // Short, human-friendly string for the comment/forum "summary" tier.
+  if (!profile?.spec) return null
+  const s = profile.spec
+  const cpu = (s.cpu?.model || 'Unknown CPU').replace(/\s+/g, ' ').trim()
+  const gpu = s.gpus?.[0]?.name?.replace(/\s+/g, ' ').trim() || 'Unknown GPU'
+  const ramGib = Math.round((s.ram?.totalBytes || 0) / (1024 ** 3))
+  const osName = s.os?.name || ''
+  return `${gpu} · ${cpu} · ${ramGib}GB · ${osName}`.trim()
+}
+
+module.exports = {
+  SPEC_VERSION,
+  scanSystemProfile,
+  readCachedProfile,
+  writeCachedProfile,
+  buildSummary,
+  computeFingerprint,
+}

--- a/renderer/src/app/Layout.tsx
+++ b/renderer/src/app/Layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router-dom"
+import { Outlet, useLocation, useNavigate } from "react-router-dom"
 import type { CSSProperties } from "react"
 import { useEffect, useRef, useState } from "react"
 import { DownBar } from "@/components/DownBar"
@@ -22,6 +22,22 @@ export function AppLayout() {
   useAppPreferencesSync()
   useKeyboardShortcuts()
   const location = useLocation()
+  const navigate = useNavigate()
+
+  // Listen for one-shot deep-link navigation actions delivered by the
+  // main process (e.g. `unioncrax://scan` from the website's "Scan in
+  // UC.Direct" buttons). Currently the only action is 'open-system-profile'
+  // which routes to /settings with the System Profile section preselected.
+  useEffect(() => {
+    const off = window.ucApp?.onNavigationAction?.((data) => {
+      if (!data || data.action !== "open-system-profile") return
+      const params = new URLSearchParams()
+      params.set("section", "system")
+      if (data.autoScan) params.set("autoScan", "1")
+      navigate(`/settings?${params.toString()}`)
+    })
+    return () => { off?.() }
+  }, [navigate])
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {

--- a/renderer/src/app/pages/SettingsPage.tsx
+++ b/renderer/src/app/pages/SettingsPage.tsx
@@ -19,6 +19,7 @@ import { SessionManager } from "@/components/SessionManager"
 import { ProfileMediaCropDialog } from "@/components/ProfileMediaCropDialog"
 import { useDiscordAccount } from "@/hooks/use-discord-account"
 import { ControllerSettingsPanel } from "@/components/ControllerSettingsPanel"
+import { SystemProfilePanel } from "@/components/SystemProfilePanel"
 import {
   SETTINGS_KEYS,
   TEXT_CONSTRAINTS,
@@ -29,7 +30,7 @@ import {
 } from "@/lib/settings-constants"
 import { LINUX_PRESETS, applyGlobalLinuxPreset, type LinuxGlobalSettings, type LinuxPresetId } from "@/lib/linux-presets"
 import { useToast } from "@/context/toast-context"
-import { useNavigate } from "react-router-dom"
+import { useNavigate, useSearchParams } from "react-router-dom"
 import {
   useMotionPreferences,
   setAnimatedBackgroundsEnabled as persistAnimatedBackgrounds,
@@ -221,7 +222,19 @@ export function SettingsPage() {
   const [cropOpen, setCropOpen] = useState(false)
   const [cropKind, setCropKind] = useState<"avatar" | "banner">("avatar")
   const [cropSourceFile, setCropSourceFile] = useState<File | null>(null)
-  const [activeSection, setActiveSection] = useState<'account' | 'downloads' | 'game-launch' | 'overlay' | 'controller' | 'advanced'>('account')
+  const [searchParams, setSearchParams] = useSearchParams()
+  // Allow deep links / route navigations to preselect a section via `?section=…`
+  // (used by the `unioncrax://scan` flow from the website).
+  const initialSection = (() => {
+    const raw = searchParams.get('section')
+    if (raw === 'account' || raw === 'downloads' || raw === 'game-launch' || raw === 'overlay' ||
+        raw === 'controller' || raw === 'system' || raw === 'advanced') {
+      return raw
+    }
+    return 'account' as const
+  })()
+  const [activeSection, setActiveSection] = useState<'account' | 'downloads' | 'game-launch' | 'overlay' | 'controller' | 'system' | 'advanced'>(initialSection)
+  const autoScanRequested = searchParams.get('autoScan') === '1'
 
   // Motion preferences (animated backgrounds + reduced motion). Hook reads
   // from electron-store + localStorage; setters below persist + sync.
@@ -1604,6 +1617,7 @@ export function SettingsPage() {
     { id: 'game-launch' as const, label: 'Game Launch', icon: Gamepad2, description: 'Launch & compatibility' },
     { id: 'controller' as const, label: 'Controller', icon: Gamepad2, description: 'Controller support' },
     { id: 'overlay' as const, label: 'Overlay', icon: Layers, description: 'In-game overlay' },
+    { id: 'system' as const, label: 'System Profile', icon: Cpu, description: 'Hardware specs & sharing' },
     { id: 'advanced' as const, label: 'Advanced', icon: Settings2, description: 'Dev tools & danger zone' },
   ]
 
@@ -3481,6 +3495,16 @@ export function SettingsPage() {
             </>
           )}
 
+          {/* ====== SYSTEM PROFILE ====== */}
+          {activeSection === 'system' && (
+            <SystemProfilePanel autoScanOnMount={autoScanRequested} onAutoScanConsumed={() => {
+              // Strip the autoScan flag so refreshing the page doesn't re-trigger.
+              const next = new URLSearchParams(searchParams)
+              next.delete('autoScan')
+              setSearchParams(next, { replace: true })
+            }} />
+          )}
+
           {/* ====== ADVANCED ====== */}
           {activeSection === 'advanced' && (
             <>
@@ -3604,6 +3628,7 @@ export function SettingsPage() {
                       <span className={`inline-block h-4 w-4 transform rounded-full transition-transform ${autoShareErrorLogs ? 'bg-black translate-x-6' : 'bg-white translate-x-1'}`} />
                     </button>
                   </div>
+                  <AttachSystemProfileToLogsToggle />
                 </CardContent>
               </Card>
 
@@ -3800,6 +3825,45 @@ export function SettingsPage() {
 
         </main>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Toggle for attaching the user's spec summary to crash/log share reports.
+ * Lives in the Privacy card, default ON because it's already opt-in at the
+ * "share my logs at all" level — this just controls whether the dev team
+ * can see "GTX 1060 / 16GB / Win10" alongside the log.
+ */
+function AttachSystemProfileToLogsToggle() {
+  const [attach, setAttach] = useState(true)
+  useEffect(() => {
+    (async () => {
+      try {
+        const v = await window.ucSettings?.get?.('attachSystemProfileToLogs')
+        if (typeof v === 'boolean') setAttach(v)
+      } catch { }
+    })()
+  }, [])
+  return (
+    <div className="flex items-center justify-between pt-2 mt-2 border-t border-white/[.05]">
+      <div>
+        <label className="text-sm font-medium cursor-pointer">Include hardware summary in error reports</label>
+        <p className="text-xs text-zinc-400 mt-1">
+          Adds a one-line spec ("RTX 4070 · 32GB · Win11") to shared logs. Helps the team reproduce platform-specific bugs. No personal info — see Settings → System Profile.
+        </p>
+      </div>
+      <button
+        onClick={async () => {
+          const next = !attach
+          setAttach(next)
+          try { await window.ucSettings?.set?.('attachSystemProfileToLogs', next) } catch { }
+        }}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${attach ? 'bg-white' : 'bg-zinc-700'}`}
+        title="Toggle hardware summary in logs"
+      >
+        <span className={`inline-block h-4 w-4 transform rounded-full transition-transform ${attach ? 'bg-black translate-x-6' : 'bg-white translate-x-1'}`} />
+      </button>
     </div>
   )
 }

--- a/renderer/src/components/DownloadCheckModal.tsx
+++ b/renderer/src/components/DownloadCheckModal.tsx
@@ -18,8 +18,11 @@ import {
   Loader2,
   ShieldAlert,
   ArrowRightLeft,
+  HardDrive,
+  Cpu,
 } from "lucide-react"
 import { ArchiveInstallModal } from "@/components/ArchiveInstallModal"
+import { compareToProfile, evaluateGpuDriver, type RequirementVerdict, type RequirementCheck, type DriverStatus } from "@/lib/system-requirements"
 
 type HostOption = {
   key: PreferredDownloadHost
@@ -56,6 +59,16 @@ type Props = {
 
 type Phase = "loading" | "ready" | "unavailable" | "error"
 
+function parseSizeStringToBytes(value: string | null | undefined): number {
+  if (!value) return 0
+  const m = String(value).trim().match(/([0-9]+(?:\.[0-9]+)?)\s*([kmgtp]?i?b)?/i)
+  if (!m) return 0
+  const n = Number(m[1])
+  const unit = (m[2] || "b").toLowerCase()
+  const mult: Record<string, number> = { b: 1, kb: 1024, kib: 1024, mb: 1024 ** 2, mib: 1024 ** 2, gb: 1024 ** 3, gib: 1024 ** 3, tb: 1024 ** 4, tib: 1024 ** 4 }
+  return Math.round(n * (mult[unit] || 1))
+}
+
 export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onCheckingChange, onConfirm, onClose }: Props) {
   const [phase, setPhase] = useState<Phase>("loading")
   const [selectedHost, setSelectedHost] = useState<PreferredDownloadHost>(defaultHost)
@@ -64,6 +77,11 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
   const [partOverrides, setPartOverrides] = useState<Record<number, { host: string; url: string }>>({})
   const [deadLinksReported, setDeadLinksReported] = useState(false)
   const [showArchiveInstall, setShowArchiveInstall] = useState(false)
+  const [storageCheck, setStorageCheck] = useState<StoragePrecheckResult | null>(null)
+  const [storageHint, setStorageHint] = useState<{ targetMedia: string | null; hasFastAlternative: boolean; isLargeInstall: boolean } | null>(null)
+  const [sysreqVerdict, setSysreqVerdict] = useState<RequirementVerdict | null>(null)
+  const [sysreqProfileMissing, setSysreqProfileMissing] = useState(false)
+  const [driverStatus, setDriverStatus] = useState<DriverStatus | null>(null)
   const reportSentRef = useRef(false)
 
   // Reset state when modal opens
@@ -145,6 +163,99 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
   useEffect(() => {
     onCheckingChange?.(Boolean(open && downloadToken && phase === "loading"))
   }, [open, downloadToken, phase, onCheckingChange])
+
+  // Storage precheck + sysreq comparison. Runs whenever the modal opens
+  // with a game so the user sees the verdict before clicking download.
+  //
+  // Storage reservation always runs (it's a functional safety net, not a
+  // privacy feature). The sysreq comparison, driver warning, and storage-
+  // type hint all *read the user's profile* and are gated on the
+  // `systemProfileVisibility.sysreqCheck` setting so users who don't want
+  // their PC inspected here can disable it from Settings → System Profile.
+  useEffect(() => {
+    if (!open || !game) {
+      setStorageCheck(null)
+      setSysreqVerdict(null)
+      setSysreqProfileMissing(false)
+      setStorageHint(null)
+      setDriverStatus(null)
+      return
+    }
+    let cancelled = false
+
+    ;(async () => {
+      const downloadBytes = game.sizeBytes || parseSizeStringToBytes(game.size)
+      const declaredInstallBytes = game.installedSizeBytes || 0
+      let precheckResult: StoragePrecheckResult | null = null
+      if (downloadBytes > 0 && window.ucStorage?.precheck) {
+        try {
+          precheckResult = await window.ucStorage.precheck({ downloadBytes, declaredInstallBytes })
+          if (!cancelled) setStorageCheck(precheckResult)
+        } catch {
+          /* ignore — pre-download check is best-effort */
+        }
+      }
+
+      // Read the privacy setting once for all profile-derived panels below.
+      let sysreqCheckEnabled = true
+      try {
+        const setting = await window.ucSettings?.get?.("systemProfileVisibility")
+        if (setting && typeof setting === "object" && setting.sysreqCheck === "off") {
+          sysreqCheckEnabled = false
+        }
+      } catch { /* default to enabled */ }
+
+      if (!sysreqCheckEnabled) return
+
+      // Storage-type hint: warn if the user is installing to a slow drive
+      // when a faster one is available. Best-effort; depends on the scanner
+      // having tagged volumes with mediaType (Windows: always; Linux: not yet).
+      if (window.ucSystemProfile?.getCached && precheckResult?.mountRoot) {
+        try {
+          const profileRes = await window.ucSystemProfile.getCached()
+          if (!cancelled && profileRes.ok && profileRes.profile) {
+            const volumes = profileRes.profile.spec.storage?.volumes || []
+            const targetRoot = precheckResult.mountRoot.replace(/\\$/, "").toUpperCase()
+            const targetVol = volumes.find(
+              (v) => v.mount && v.mount.toUpperCase().replace(/\\$/, "") === targetRoot
+            )
+            const targetMedia = targetVol?.mediaType ?? null
+            const hasFastAlternative = volumes.some(
+              (v) => v.mediaType === "ssd" || v.mediaType === "nvme"
+            ) && targetMedia === "hdd"
+            // Threshold: 30+ GB installed is when HDD load times start hurting.
+            const isLargeInstall = (precheckResult.extractBytes || 0) > 30 * 1024 ** 3
+            setStorageHint({ targetMedia, hasFastAlternative, isLargeInstall })
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+
+      const hasReqs = game.minRequirements || game.recommendedRequirements
+      if (window.ucSystemProfile?.getCached) {
+        try {
+          const res = await window.ucSystemProfile.getCached()
+          if (cancelled) return
+          if (!res.ok || !res.profile) {
+            if (hasReqs) setSysreqProfileMissing(true)
+            return
+          }
+          if (hasReqs) {
+            const target = game.recommendedRequirements || game.minRequirements || null
+            setSysreqVerdict(compareToProfile(res.profile.spec, target))
+          }
+          // Driver status is independent of game sysreq — we can warn even
+          // for games whose specs aren't published yet.
+          setDriverStatus(evaluateGpuDriver(res.profile.spec))
+        } catch {
+          /* ignore */
+        }
+      }
+    })()
+
+    return () => { cancelled = true }
+  }, [open, game])
 
   // Auto-report dead links when game is fully unavailable
   useEffect(() => {
@@ -504,6 +615,88 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
               </div>
             )}
 
+            {/* Storage reservation summary */}
+            {storageCheck && (
+              <div className={`rounded-lg border px-3 py-2 text-xs space-y-1.5 ${
+                storageCheck.ok
+                  ? "border-emerald-500/20 bg-emerald-500/5 text-emerald-200"
+                  : "border-red-500/30 bg-red-500/10 text-red-200"
+              }`}>
+                <div className="flex items-center gap-1.5 font-medium">
+                  <HardDrive className="h-3.5 w-3.5" />
+                  {storageCheck.ok
+                    ? "Storage reserved"
+                    : `Not enough free space — short ${storageCheck.humanShortfall}`}
+                </div>
+                <div className="grid grid-cols-3 gap-2 text-[11px]">
+                  <div><span className="opacity-70">Download:</span> {storageCheck.humanRequired ? formatBytes(storageCheck.downloadBytes) : "—"}</div>
+                  <div><span className="opacity-70">Extract:</span> {formatBytes(storageCheck.extractBytes)}</div>
+                  <div><span className="opacity-70">Free:</span> {storageCheck.humanAvailable}</div>
+                </div>
+                {storageCheck.alreadyReservedBytes > 0 && (
+                  <div className="text-[10px] opacity-70">
+                    {formatBytes(storageCheck.alreadyReservedBytes)} already reserved by other in-flight downloads.
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Storage-type hint: HDD install with SSDs available, large install. */}
+            {storageHint && storageHint.hasFastAlternative && storageHint.isLargeInstall && (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200 space-y-1">
+                <div className="flex items-center gap-1.5 font-medium">
+                  <HardDrive className="h-3.5 w-3.5" />
+                  Slow install drive detected
+                </div>
+                <p className="text-[11px] opacity-80">
+                  Your download drive is an HDD. Large games load noticeably faster from an SSD or NVMe — open Settings to switch the download path if you'd prefer.
+                </p>
+              </div>
+            )}
+
+            {/* System requirement comparison */}
+            {sysreqProfileMissing && (game?.minRequirements || game?.recommendedRequirements) && (
+              <div className="rounded-lg border border-white/[.07] bg-zinc-800/30 px-3 py-2 text-xs text-zinc-300">
+                <div className="flex items-center gap-1.5 font-medium">
+                  <Cpu className="h-3.5 w-3.5" />
+                  Scan your PC to see if it meets the requirements
+                </div>
+                <div className="text-[11px] text-zinc-400 mt-1">
+                  Settings → System Profile → Scan now.
+                </div>
+              </div>
+            )}
+            {sysreqVerdict && sysreqVerdict.checks.length > 0 && (
+              <SysreqPanel verdict={sysreqVerdict} />
+            )}
+
+            {driverStatus?.status === "stale" && driverStatus.ageDays != null && (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200 space-y-1">
+                <div className="flex items-center gap-1.5 font-medium">
+                  <AlertTriangle className="h-3.5 w-3.5" />
+                  GPU driver is {Math.floor(driverStatus.ageDays / 30)} month{Math.floor(driverStatus.ageDays / 30) === 1 ? "" : "s"} old
+                </div>
+                <p className="text-[11px] opacity-80">
+                  Older drivers can cause crashes or poor performance in new games. Consider updating before installing.
+                </p>
+                {driverStatus.driverPageUrl && (
+                  <a
+                    href={driverStatus.driverPageUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      window.ucSystem?.openExternal?.(driverStatus.driverPageUrl!)
+                    }}
+                    className="inline-flex items-center gap-1 text-[11px] underline hover:no-underline"
+                  >
+                    <ExternalLink className="h-2.5 w-2.5" />
+                    {driverStatus.vendor ? `${driverStatus.vendor.toUpperCase()} drivers` : "Vendor drivers"}
+                  </a>
+                )}
+              </div>
+            )}
+
             {/* Dead links reported notice */}
             {deadLinksReported && (
               <p className="text-[11px] text-zinc-400/60 text-center">
@@ -521,7 +714,12 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
                 Install from archive
               </Button>
               <Button
-                disabled={(hasDeadParts && !allPartsHandled) || !currentHostAvail || currentHostAvail.totalParts === 0}
+                disabled={
+                  (hasDeadParts && !allPartsHandled) ||
+                  !currentHostAvail ||
+                  currentHostAvail.totalParts === 0 ||
+                  (storageCheck != null && !storageCheck.ok)
+                }
                 onClick={() => {
                   // Auto-report dead links on download confirm
                   if (!reportSentRef.current && availability) {
@@ -559,7 +757,9 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
                   ? "Host unavailable"
                   : hasDeadParts && !allPartsHandled
                     ? "Resolve dead parts first"
-                    : `Download with ${hostLabel(selectedHost)}`}
+                    : storageCheck != null && !storageCheck.ok
+                      ? "Free up space first"
+                      : `Download with ${hostLabel(selectedHost)}`}
               </Button>
             </div>
           </div>
@@ -572,6 +772,63 @@ export function DownloadCheckModal({ open, game, downloadToken, defaultHost, onC
         game={game}
         onClose={() => setShowArchiveInstall(false)}
       />
+    </div>
+  )
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (!bytes || !Number.isFinite(bytes)) return "—"
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  const digits = value >= 10 || unit === 0 ? 0 : 1
+  return `${value.toFixed(digits)} ${units[unit]}`
+}
+
+function SysreqPanel({ verdict }: { verdict: RequirementVerdict }) {
+  const containerColor =
+    verdict.status === "pass" ? "border-emerald-500/20 bg-emerald-500/5 text-emerald-200" :
+    verdict.status === "warn" ? "border-amber-500/30 bg-amber-500/10 text-amber-200" :
+    verdict.status === "fail" ? "border-red-500/30 bg-red-500/10 text-red-200" :
+    "border-white/[.07] bg-zinc-800/30 text-zinc-300"
+
+  const summary =
+    verdict.status === "pass" ? "Your PC meets all checked requirements." :
+    verdict.status === "warn" ? `${verdict.warnCount} requirement${verdict.warnCount === 1 ? " is" : "s are"} close to the minimum.` :
+    verdict.status === "fail" ? `${verdict.failCount} requirement${verdict.failCount === 1 ? "" : "s"} not met.` :
+    "Compared against your scanned hardware."
+
+  return (
+    <div className={`rounded-lg border px-3 py-2 text-xs space-y-1.5 ${containerColor}`}>
+      <div className="flex items-center gap-1.5 font-medium">
+        <Cpu className="h-3.5 w-3.5" />
+        {summary}
+      </div>
+      <div className="space-y-0.5">
+        {verdict.checks.map((c) => <SysreqRow key={c.component} check={c} />)}
+      </div>
+    </div>
+  )
+}
+
+function SysreqRow({ check }: { check: RequirementCheck }) {
+  const icon = check.status === "pass" ? <CheckCircle2 className="h-3 w-3 text-emerald-400" />
+    : check.status === "warn" ? <AlertTriangle className="h-3 w-3 text-amber-400" />
+    : check.status === "fail" ? <CircleX className="h-3 w-3 text-red-400" />
+    : <span className="h-3 w-3 rounded-full bg-zinc-500/40 inline-block" />
+  return (
+    <div className="flex items-start gap-2 text-[11px] py-0.5">
+      <span className="pt-0.5 shrink-0">{icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className="uppercase text-[10px] opacity-70 mr-1">{check.component}</span>
+        <span className="opacity-90">{check.have || "Unknown"}</span>
+        <span className="opacity-50"> · needs </span>
+        <span className="opacity-90">{check.required || "?"}</span>
+      </span>
     </div>
   )
 }

--- a/renderer/src/components/SystemProfilePanel.tsx
+++ b/renderer/src/components/SystemProfilePanel.tsx
@@ -1,0 +1,751 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Cpu, Loader2, RefreshCw, Monitor, HardDrive, Zap, MemoryStick, Trash2, ShieldCheck, CloudUpload, CloudOff, CheckCircle2, Laptop, Link2, X, Check, Pencil, TrendingUp } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { getApiBaseUrl } from "@/lib/api"
+
+const DEFAULT_VISIBILITY: SystemProfileVisibility = {
+  comments: "off",
+  forums: "off",
+  profilePublic: "off",
+  sysreqCheck: "on",
+}
+
+function formatBytes(bytes: number | null | undefined): string {
+  if (!bytes || !Number.isFinite(bytes)) return "—"
+  const units = ["B", "KB", "MB", "GB", "TB"]
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  const digits = value >= 10 || unit === 0 ? 0 : 1
+  return `${value.toFixed(digits)} ${units[unit]}`
+}
+
+function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "never"
+  const ts = new Date(iso).getTime()
+  if (!Number.isFinite(ts)) return "never"
+  const diff = Date.now() - ts
+  const min = Math.floor(diff / 60000)
+  if (min < 1) return "just now"
+  if (min < 60) return `${min} min ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} hr ago`
+  const day = Math.floor(hr / 24)
+  if (day < 30) return `${day} day${day === 1 ? "" : "s"} ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+type VisibilityRowProps = {
+  label: string
+  description: string
+  value: SystemProfileVisibilityTier
+  onChange: (next: SystemProfileVisibilityTier) => void
+  allowFull?: boolean
+}
+
+function VisibilityRow({ label, description, value, onChange, allowFull = true }: VisibilityRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium">{label}</div>
+        <div className="text-xs text-zinc-400 mt-0.5">{description}</div>
+      </div>
+      <Select value={value} onValueChange={(v) => onChange(v as SystemProfileVisibilityTier)}>
+        <SelectTrigger className="w-32 h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="off">Off</SelectItem>
+          <SelectItem value="summary">Summary</SelectItem>
+          {allowFull && <SelectItem value="full">Full spec</SelectItem>}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+type SyncState = "idle" | "uploading" | "synced" | "error" | "offline"
+
+type Props = {
+  /** When true (e.g. deep-linked via `unioncrax://scan`), trigger a fresh scan
+   *  as soon as the panel mounts. */
+  autoScanOnMount?: boolean
+  /** Called once after the auto-scan has been kicked off, so the parent can
+   *  clear the triggering query param. */
+  onAutoScanConsumed?: () => void
+}
+
+export function SystemProfilePanel({ autoScanOnMount = false, onAutoScanConsumed }: Props = {}) {
+  const [profile, setProfile] = useState<SystemProfile | null>(null)
+  const [scanning, setScanning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [visibility, setVisibility] = useState<SystemProfileVisibility>(DEFAULT_VISIBILITY)
+  const [sysreqCheck, setSysreqCheck] = useState<"on" | "off">("on")
+  const [syncState, setSyncState] = useState<SyncState>("idle")
+  const [syncError, setSyncError] = useState<string | null>(null)
+  const baseUrlRef = useRef<string | undefined>(undefined)
+
+  const loadCached = useCallback(async () => {
+    if (!window.ucSystemProfile?.getCached) return
+    try {
+      const res = await window.ucSystemProfile.getCached()
+      if (res.ok) setProfile(res.profile)
+    } catch (err: any) {
+      setError(err?.message || String(err))
+    }
+  }, [])
+
+  const loadSettings = useCallback(async () => {
+    try {
+      const stored = await window.ucSettings?.get?.("systemProfileVisibility")
+      if (stored && typeof stored === "object") {
+        setVisibility({ ...DEFAULT_VISIBILITY, ...stored })
+        if (stored.sysreqCheck) setSysreqCheck(stored.sysreqCheck)
+      }
+    } catch { }
+  }, [])
+
+  useEffect(() => {
+    try { baseUrlRef.current = getApiBaseUrl() } catch { /* not configured yet */ }
+    loadCached()
+    loadSettings()
+  }, [loadCached, loadSettings])
+
+  // If we were opened via `unioncrax://scan`, fire a fresh scan immediately
+  // and let the parent clear the URL flag so a page refresh doesn't repeat.
+  const autoScanFiredRef = useRef(false)
+  useEffect(() => {
+    if (!autoScanOnMount || autoScanFiredRef.current) return
+    if (!window.ucSystemProfile?.scan) return
+    autoScanFiredRef.current = true
+    void (async () => {
+      try {
+        setScanning(true)
+        const res = await window.ucSystemProfile!.scan({ force: true })
+        if (res.ok && res.profile) setProfile(res.profile)
+      } catch (err: any) {
+        setError(err?.message || String(err))
+      } finally {
+        setScanning(false)
+        onAutoScanConsumed?.()
+      }
+    })()
+  }, [autoScanOnMount, onAutoScanConsumed])
+
+  // Compute whether any online surface is enabled — the gate for uploading.
+  const anyOnlineSurfaceOn = useCallback((v: SystemProfileVisibility) => (
+    v.comments !== "off" || v.forums !== "off" || v.profilePublic !== "off"
+  ), [])
+
+  const uploadIfOptedIn = useCallback(async (v: SystemProfileVisibility) => {
+    if (!anyOnlineSurfaceOn(v)) {
+      setSyncState("idle")
+      return
+    }
+    if (!window.ucSystemProfile?.upload) {
+      setSyncState("offline")
+      return
+    }
+    setSyncState("uploading")
+    setSyncError(null)
+    try {
+      const res = await window.ucSystemProfile.upload(baseUrlRef.current)
+      if (!res.ok) {
+        setSyncState("error")
+        setSyncError(res.error || `Upload failed (HTTP ${res.status || "?"})`)
+        return
+      }
+      setSyncState("synced")
+    } catch (err: any) {
+      setSyncState("error")
+      setSyncError(err?.message || String(err))
+    }
+  }, [anyOnlineSurfaceOn])
+
+  const runScan = useCallback(async (force: boolean) => {
+    if (!window.ucSystemProfile?.scan) return
+    setScanning(true)
+    setError(null)
+    try {
+      const res = await window.ucSystemProfile.scan({ force })
+      if (!res.ok) {
+        setError(res.error || "Scan failed.")
+        return
+      }
+      if (res.profile) {
+        setProfile(res.profile)
+        // Auto-upload if user has opted into any online surface. Otherwise
+        // the spec stays purely local until they flip a switch.
+        void uploadIfOptedIn(visibility)
+      }
+    } catch (err: any) {
+      setError(err?.message || String(err))
+    } finally {
+      setScanning(false)
+    }
+  }, [uploadIfOptedIn, visibility])
+
+  const updateVisibility = useCallback(async (patch: Partial<SystemProfileVisibility>) => {
+    const next = { ...visibility, ...patch }
+    setVisibility(next)
+    if (patch.sysreqCheck) setSysreqCheck(patch.sysreqCheck === "off" ? "off" : "on")
+    try { await window.ucSettings?.set?.("systemProfileVisibility", next) } catch { }
+
+    // Mirror to server: if any online surface is on, push tiers + spec.
+    // If everything is now off, delete the server-side copy.
+    if (anyOnlineSurfaceOn(next)) {
+      if (window.ucSystemProfile?.serverSetVisibility) {
+        try {
+          await window.ucSystemProfile.serverSetVisibility(baseUrlRef.current, {
+            comments: next.comments === "summary" ? "summary" : "off",
+            forums: next.forums === "summary" ? "summary" : "off",
+            profilePublic: next.profilePublic,
+          })
+        } catch { /* swallow, will retry on next scan/visibility change */ }
+      }
+      if (profile) void uploadIfOptedIn(next)
+    } else if (!anyOnlineSurfaceOn(next) && anyOnlineSurfaceOn(visibility)) {
+      // All surfaces just flipped off — remove the server-side spec.
+      if (window.ucSystemProfile?.serverDelete) {
+        try { await window.ucSystemProfile.serverDelete(baseUrlRef.current) } catch { }
+      }
+      setSyncState("idle")
+    }
+  }, [visibility, anyOnlineSurfaceOn, uploadIfOptedIn, profile])
+
+  const clearProfile = useCallback(async () => {
+    if (!window.ucSystemProfile?.clearCache) return
+    try {
+      await window.ucSystemProfile.clearCache()
+      setProfile(null)
+      // Also delete server copy so we don't have stale specs upstream.
+      if (window.ucSystemProfile.serverDelete) {
+        try { await window.ucSystemProfile.serverDelete(baseUrlRef.current) } catch { }
+      }
+      setSyncState("idle")
+    } catch (err: any) {
+      setError(err?.message || String(err))
+    }
+  }, [])
+
+  const spec = profile?.spec
+  const primaryGpu = spec?.gpus?.[0]
+  const ramGib = spec ? Math.round((spec.ram.totalBytes || 0) / (1024 ** 3)) : null
+
+  return (
+    <div className="space-y-4">
+      <Card className="border-white/[.07]">
+        <CardContent className="p-6 space-y-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <h2 className="text-lg font-semibold">System Profile</h2>
+                {profile && <Badge className="bg-zinc-800 text-zinc-200 border-zinc-700 text-[10px]">fp:{profile.fingerprint.slice(0, 8)}</Badge>}
+                <SyncStatusBadge state={syncState} error={syncError} />
+              </div>
+              <p className="text-sm text-zinc-400 mt-1">
+                Scan your PC's hardware to power pre-download requirement checks, library filtering, and an opt-in spec badge on comments and your public profile. Nothing is uploaded unless you flip a sharing switch below.
+              </p>
+              <p className="text-[11px] text-zinc-500 mt-2">
+                Last scan: <span className="text-zinc-300">{relativeTime(profile?.capturedAt)}</span>
+                {profile && <> · took {profile.scanDurationMs}ms</>}
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 shrink-0">
+              <Button onClick={() => runScan(true)} disabled={scanning} size="sm">
+                {scanning ? (
+                  <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Scanning…</>
+                ) : profile ? (
+                  <><RefreshCw className="h-4 w-4 mr-2" /> Rescan</>
+                ) : (
+                  <><Cpu className="h-4 w-4 mr-2" /> Scan now</>
+                )}
+              </Button>
+              {profile && (
+                <Button onClick={clearProfile} size="sm" variant="outline">
+                  <Trash2 className="h-3.5 w-3.5 mr-2" /> Clear
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+              {error}
+            </div>
+          )}
+
+          {spec && (
+            <div className="grid sm:grid-cols-2 gap-3">
+              <SpecTile icon={<Cpu className="h-4 w-4" />} label="CPU" value={spec.cpu.model || "Unknown"}
+                sub={spec.cpu.cores ? `${spec.cpu.cores} cores / ${spec.cpu.threads ?? "?"} threads · ${spec.cpu.baseClockMhz ? `${(spec.cpu.baseClockMhz / 1000).toFixed(2)} GHz` : ""}` : null} />
+              <SpecTile icon={<Zap className="h-4 w-4" />} label="GPU" value={primaryGpu?.name || "Unknown"}
+                sub={primaryGpu ? [
+                  primaryGpu.vendor !== "unknown" ? primaryGpu.vendor.toUpperCase() : null,
+                  primaryGpu.vramBytes ? `${formatBytes(primaryGpu.vramBytes)} VRAM` : null,
+                  primaryGpu.driverVersion ? `driver ${primaryGpu.driverVersion}` : null,
+                ].filter(Boolean).join(" · ") : null} />
+              <SpecTile icon={<MemoryStick className="h-4 w-4" />} label="RAM" value={ramGib ? `${ramGib} GB` : "Unknown"}
+                sub={spec.ram.speedMhz ? `${spec.ram.speedMhz} MHz · ${spec.ram.channels || ""}` : null} />
+              <SpecTile icon={<Monitor className="h-4 w-4" />} label="OS" value={`${spec.os.name} ${spec.os.version || ""}`}
+                sub={spec.os.build ? `build ${spec.os.build}` : null} />
+              <SpecTile icon={<HardDrive className="h-4 w-4" />} label="Storage" value={`${spec.storage.drives.length} drive${spec.storage.drives.length === 1 ? "" : "s"}`}
+                sub={spec.storage.drives.slice(0, 2).map((d) => `${d.mediaType?.toUpperCase() || ""} ${formatBytes(d.sizeBytes)}`).join(" · ") || null} />
+              <SpecTile icon={<Monitor className="h-4 w-4" />} label="Display" value={spec.displays[0] ? `${spec.displays[0].width}×${spec.displays[0].height}` : "Unknown"}
+                sub={spec.displays[0]?.refreshHz ? `${spec.displays[0].refreshHz} Hz · DX${spec.graphics.directx || "?"}${spec.graphics.vulkan ? ` · Vulkan ${spec.graphics.vulkan}` : ""}` : null} />
+            </div>
+          )}
+
+          {spec && spec.gpus.length > 1 && (
+            <div className="rounded-md border border-white/[.07] bg-zinc-900/40 px-3 py-2 text-xs text-zinc-400">
+              <span className="font-medium text-zinc-300">Additional GPUs:</span> {spec.gpus.slice(1).map((g) => g.name).filter(Boolean).join(", ")}
+            </div>
+          )}
+
+          {!profile && !scanning && (
+            <div className="rounded-md border border-dashed border-white/10 bg-zinc-900/30 px-4 py-6 text-sm text-zinc-400 text-center">
+              No scan yet. Click <span className="text-zinc-200 font-medium">Scan now</span> to detect your hardware.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-white/[.07]">
+        <CardContent className="p-6 space-y-4">
+          <div className="flex items-start gap-2">
+            <ShieldCheck className="h-4 w-4 text-zinc-300 mt-1" />
+            <div>
+              <h2 className="text-lg font-semibold">Sharing &amp; visibility</h2>
+              <p className="text-sm text-zinc-400 mt-1">
+                Choose where your specs are visible. <b>Summary</b> shows a short string like &ldquo;RTX 4070 · 32GB · Win11&rdquo;. <b>Full spec</b> shows the detailed sheet. Existing comments and forum posts keep the specs they had when posted.
+              </p>
+            </div>
+          </div>
+
+          <div className="divide-y divide-white/[.06]">
+            <VisibilityRow
+              label="Comment badge"
+              description="Show a spec chip next to your comments on game pages."
+              value={visibility.comments}
+              onChange={(v) => updateVisibility({ comments: v })}
+              allowFull={false}
+            />
+            <VisibilityRow
+              label="Forum posts"
+              description="Show a spec chip on your forum posts."
+              value={visibility.forums}
+              onChange={(v) => updateVisibility({ forums: v })}
+              allowFull={false}
+            />
+            <VisibilityRow
+              label="Public profile"
+              description="Show a spec card on your public UC profile."
+              value={visibility.profilePublic}
+              onChange={(v) => updateVisibility({ profilePublic: v })}
+            />
+            <div className="flex items-start justify-between gap-4 py-2">
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium">Pre-download requirement check</div>
+                <div className="text-xs text-zinc-400 mt-0.5">
+                  Compare a game's minimum and recommended specs to your hardware before downloading. Stays on your device.
+                </div>
+              </div>
+              <Select value={sysreqCheck} onValueChange={(v) => updateVisibility({ sysreqCheck: v as "on" | "off" })}>
+                <SelectTrigger className="w-32 h-8 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="on">On</SelectItem>
+                  <SelectItem value="off">Off</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <p className="text-[11px] text-zinc-500">
+            Uploading specs to the UC server is opt-in and only happens when at least one online surface is set above &ldquo;Off&rdquo;.
+          </p>
+        </CardContent>
+      </Card>
+
+      {anyOnlineSurfaceOn(visibility) && <DevicesSection baseUrl={baseUrlRef.current} currentFingerprint={profile?.fingerprint ?? null} />}
+      {anyOnlineSurfaceOn(visibility) && <SharesSection baseUrl={baseUrlRef.current} />}
+      {profile && anyOnlineSurfaceOn(visibility) && <UpgradeSuggesterSection baseUrl={baseUrlRef.current} />}
+    </div>
+  )
+}
+
+// ─── Upgrade suggester ──────────────────────────────────────────────────────
+
+type UpgradeReport = {
+  considered: number
+  smoothCount: number
+  bottleneckedCount: number
+  unknownCount: number
+  primaryUnlockCount: number | null
+  bottlenecks: Array<{
+    component: "cpu" | "gpu" | "ram" | "storage" | "directx"
+    gamesAffected: number
+    suggestion: string | null
+    examples: Array<{ appid: string; name: string | null }>
+  }>
+}
+
+function UpgradeSuggesterSection({ baseUrl }: { baseUrl: string | undefined }) {
+  const [report, setReport] = useState<UpgradeReport | null>(null)
+  const [reason, setReason] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    (async () => {
+      if (!window.ucSystemProfile?.upgradeSuggest) {
+        setLoading(false)
+        return
+      }
+      try {
+        const res = await window.ucSystemProfile.upgradeSuggest(baseUrl)
+        if (res.ok && res.report) {
+          setReport(res.report)
+        } else if (res.ok && !res.report) {
+          setReason(res.reason || "No wishlist games to evaluate yet.")
+        } else if (!res.ok) {
+          setReason(res.reason || res.error || null)
+        }
+      } catch (err: any) {
+        setReason(err?.message || String(err))
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [baseUrl])
+
+  if (loading) {
+    return (
+      <Card className="border-white/[.07]">
+        <CardContent className="p-6 flex items-center gap-2 text-sm text-zinc-400">
+          <Loader2 className="h-4 w-4 animate-spin" /> Analyzing your wishlist…
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Don't render the card at all if we have nothing useful to say.
+  if (!report && !reason) return null
+  if (report && report.bottleneckedCount === 0 && report.considered > 0) {
+    // Pure good-news state — show a small congrats card.
+    return (
+      <Card className="border-emerald-500/30 bg-emerald-500/[.04]">
+        <CardContent className="p-6 space-y-1">
+          <div className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4 text-emerald-300" />
+            <h2 className="text-lg font-semibold">Your PC clears every game in your wishlist</h2>
+          </div>
+          <p className="text-sm text-zinc-400">
+            {report.smoothCount} of {report.considered} game{report.considered === 1 ? "" : "s"} comfortable on your current rig.
+            {report.unknownCount > 0 && ` ${report.unknownCount} game${report.unknownCount === 1 ? "" : "s"} we couldn't evaluate yet.`}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="border-white/[.07]">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex items-start gap-2">
+          <TrendingUp className="h-4 w-4 text-zinc-300 mt-1" />
+          <div>
+            <h2 className="text-lg font-semibold">Upgrade suggestions</h2>
+            <p className="text-sm text-zinc-400 mt-1">
+              {report
+                ? <>Based on your wishlist: {report.smoothCount} smooth · <span className="text-zinc-200">{report.bottleneckedCount} bottlenecked</span>{report.unknownCount > 0 && <> · {report.unknownCount} unknown</>}</>
+                : (reason || "No data to evaluate yet.")}
+            </p>
+          </div>
+        </div>
+
+        {report?.bottlenecks && report.bottlenecks.length > 0 && (
+          <div className="space-y-3">
+            {report.bottlenecks.slice(0, 3).map((b, i) => (
+              <div key={b.component} className={`rounded-lg border px-3 py-2 ${
+                i === 0
+                  ? "border-amber-500/40 bg-amber-500/[.05]"
+                  : "border-white/[.07] bg-zinc-900/40"
+              }`}>
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] uppercase tracking-wider text-zinc-500">{b.component}</span>
+                    <Badge className="bg-zinc-800 text-zinc-200 border-zinc-700 text-[10px]">
+                      {b.gamesAffected} game{b.gamesAffected === 1 ? "" : "s"}
+                    </Badge>
+                    {i === 0 && <Badge className="bg-amber-500/15 text-amber-200 border-amber-500/30 text-[10px]">biggest bottleneck</Badge>}
+                  </div>
+                </div>
+                {b.suggestion && (
+                  <p className="text-sm text-zinc-200 mt-1">{b.suggestion}</p>
+                )}
+                {b.examples.length > 0 && (
+                  <p className="text-[11px] text-zinc-500 mt-1 truncate">
+                    e.g. {b.examples.map((e) => e.name || e.appid).join(", ")}
+                    {b.gamesAffected > b.examples.length && ` (+${b.gamesAffected - b.examples.length} more)`}
+                  </p>
+                )}
+              </div>
+            ))}
+            {report.primaryUnlockCount != null && report.primaryUnlockCount > 0 && (
+              <p className="text-xs text-zinc-400">
+                Fixing the biggest bottleneck would unlock {report.primaryUnlockCount} wishlisted game{report.primaryUnlockCount === 1 ? "" : "s"} at smooth settings.
+              </p>
+            )}
+          </div>
+        )}
+
+        <p className="text-[11px] text-zinc-500">
+          Suggestions are a rough heuristic, not an authoritative benchmark. Games with no published requirements aren't considered.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Multi-rig devices ──────────────────────────────────────────────────────
+
+type DeviceRow = { fingerprint: string; deviceName: string | null; summary: string | null; sourceAppVersion: string | null; capturedAt: string; isActive: boolean }
+
+function DevicesSection({ baseUrl, currentFingerprint }: { baseUrl: string | undefined; currentFingerprint: string | null }) {
+  const [devices, setDevices] = useState<DeviceRow[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [editingFp, setEditingFp] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState("")
+
+  const reload = useCallback(async () => {
+    if (!window.ucSystemProfile?.listDevices) return
+    setLoading(true)
+    try {
+      const res = await window.ucSystemProfile.listDevices(baseUrl)
+      setDevices(res.ok ? res.devices ?? [] : [])
+    } finally {
+      setLoading(false)
+    }
+  }, [baseUrl])
+
+  useEffect(() => { void reload() }, [reload])
+
+  if (!devices) return null
+  if (devices.length <= 1) return null // only show when the user has multiple rigs
+
+  return (
+    <Card className="border-white/[.07]">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex items-start gap-2">
+          <Laptop className="h-4 w-4 text-zinc-300 mt-1" />
+          <div>
+            <h2 className="text-lg font-semibold">My PCs</h2>
+            <p className="text-sm text-zinc-400 mt-1">
+              You&apos;ve scanned more than one device. Pick which one UnionCrax should treat as your active rig — that&apos;s what appears on comments, forums, and the &quot;Can my PC run&quot; filter.
+            </p>
+          </div>
+        </div>
+        <div className="divide-y divide-white/[.06]">
+          {devices.map((d) => (
+            <div key={d.fingerprint} className="flex items-center gap-3 py-2">
+              <div className="flex-1 min-w-0">
+                {editingFp === d.fingerprint ? (
+                  <div className="flex items-center gap-2">
+                    <Input value={editingName} onChange={(e) => setEditingName(e.target.value)} placeholder="Device name" className="h-7 text-xs" />
+                    <Button size="sm" variant="ghost" onClick={async () => {
+                      await window.ucSystemProfile?.renameDevice?.(baseUrl, d.fingerprint, editingName.trim() || null)
+                      setEditingFp(null)
+                      void reload()
+                    }}>
+                      <Check className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => setEditingFp(null)}>
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span className="text-sm font-medium truncate">{d.deviceName || `PC ${d.fingerprint.slice(0, 6)}`}</span>
+                    <button onClick={() => { setEditingFp(d.fingerprint); setEditingName(d.deviceName || "") }} className="opacity-50 hover:opacity-100" title="Rename">
+                      <Pencil className="h-3 w-3" />
+                    </button>
+                    {d.isActive && <Badge className="bg-emerald-500/10 text-emerald-300 border-emerald-500/30 text-[10px]">active</Badge>}
+                    {d.fingerprint === currentFingerprint && !d.isActive && <Badge className="bg-zinc-800 text-zinc-300 border-zinc-700 text-[10px]">this PC</Badge>}
+                  </div>
+                )}
+                <div className="text-[11px] text-zinc-400 mt-0.5 truncate">
+                  {d.summary || "(no summary)"} · scanned {new Date(d.capturedAt).toLocaleDateString()}
+                </div>
+              </div>
+              {!d.isActive && (
+                <Button size="sm" variant="outline" disabled={loading} onClick={async () => {
+                  await window.ucSystemProfile?.activateDevice?.(baseUrl, d.fingerprint)
+                  void reload()
+                }}>
+                  Make active
+                </Button>
+              )}
+              <Button size="sm" variant="ghost" disabled={loading} onClick={async () => {
+                if (!confirm("Forget this PC's profile from UnionCrax? Old posts that snapshot this device keep their data.")) return
+                await window.ucSystemProfile?.deleteDevice?.(baseUrl, d.fingerprint)
+                void reload()
+              }} title="Forget this device">
+                <Trash2 className="h-3.5 w-3.5 text-red-400" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ─── Share-a-spec ───────────────────────────────────────────────────────────
+
+type ShareRow = { shortCode: string; tier: "summary" | "full"; viewCount: number; expiresAt: string | null; createdAt: string }
+
+function SharesSection({ baseUrl }: { baseUrl: string | undefined }) {
+  const [shares, setShares] = useState<ShareRow[] | null>(null)
+  const [creating, setCreating] = useState(false)
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    if (!window.ucSystemProfile?.listShares) return
+    const res = await window.ucSystemProfile.listShares(baseUrl)
+    setShares(res.ok ? res.shares ?? [] : [])
+  }, [baseUrl])
+
+  useEffect(() => { void reload() }, [reload])
+
+  const create = useCallback(async (tier: "summary" | "full") => {
+    setCreating(true)
+    try {
+      await window.ucSystemProfile?.createShare?.(baseUrl, { tier })
+      await reload()
+    } finally {
+      setCreating(false)
+    }
+  }, [baseUrl, reload])
+
+  const buildShareUrl = (code: string) => {
+    const apiBase = baseUrl?.replace(/\/$/, "") || ""
+    return apiBase ? `${apiBase}/specs/${code}` : `/specs/${code}`
+  }
+
+  return (
+    <Card className="border-white/[.07]">
+      <CardContent className="p-6 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-2">
+            <Link2 className="h-4 w-4 text-zinc-300 mt-1" />
+            <div>
+              <h2 className="text-lg font-semibold">Shared spec links</h2>
+              <p className="text-sm text-zinc-400 mt-1">
+                Mint a short URL anyone can open to see your specs (frozen at create time). Useful for &ldquo;can your friend&apos;s PC run this?&rdquo; conversations. Revokeable any time.
+              </p>
+            </div>
+          </div>
+          <div className="flex gap-1.5 shrink-0">
+            <Button size="sm" variant="outline" disabled={creating} onClick={() => create("summary")}>Summary</Button>
+            <Button size="sm" disabled={creating} onClick={() => create("full")}>{creating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Full spec"}</Button>
+          </div>
+        </div>
+
+        {shares && shares.length === 0 && (
+          <p className="text-xs text-zinc-500">No links yet. Click <span className="text-zinc-300">Summary</span> or <span className="text-zinc-300">Full spec</span> to create one.</p>
+        )}
+
+        {shares && shares.length > 0 && (
+          <div className="divide-y divide-white/[.06]">
+            {shares.map((s) => {
+              const url = buildShareUrl(s.shortCode)
+              return (
+                <div key={s.shortCode} className="flex items-center gap-3 py-2 text-sm">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <code className="text-xs font-mono text-zinc-200">{url}</code>
+                      <Badge className="bg-zinc-800 text-zinc-300 border-zinc-700 text-[10px]">{s.tier}</Badge>
+                    </div>
+                    <div className="text-[11px] text-zinc-400 mt-0.5">
+                      {s.viewCount} view{s.viewCount === 1 ? "" : "s"} · created {new Date(s.createdAt).toLocaleDateString()}
+                      {s.expiresAt && ` · expires ${new Date(s.expiresAt).toLocaleDateString()}`}
+                    </div>
+                  </div>
+                  <Button size="sm" variant="outline" onClick={async () => {
+                    try { await navigator.clipboard.writeText(url); setCopied(s.shortCode); setTimeout(() => setCopied(null), 1500) } catch { /* swallow */ }
+                  }}>
+                    {copied === s.shortCode ? "Copied!" : "Copy"}
+                  </Button>
+                  <Button size="sm" variant="ghost" onClick={async () => {
+                    if (!confirm("Revoke this share link? Anyone with it will get a 404.")) return
+                    await window.ucSystemProfile?.revokeShare?.(baseUrl, s.shortCode)
+                    void reload()
+                  }} title="Revoke">
+                    <Trash2 className="h-3.5 w-3.5 text-red-400" />
+                  </Button>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function SyncStatusBadge({ state, error }: { state: SyncState; error: string | null }) {
+  if (state === "idle") {
+    return (
+      <Badge className="bg-zinc-900 text-zinc-400 border-zinc-800 text-[10px]" title="Profile is local only — flip a sharing switch below to publish.">
+        <CloudOff className="h-2.5 w-2.5 mr-1" /> local only
+      </Badge>
+    )
+  }
+  if (state === "uploading") {
+    return (
+      <Badge className="bg-zinc-800 text-zinc-300 border-zinc-700 text-[10px]">
+        <Loader2 className="h-2.5 w-2.5 mr-1 animate-spin" /> syncing
+      </Badge>
+    )
+  }
+  if (state === "synced") {
+    return (
+      <Badge className="bg-emerald-500/10 text-emerald-300 border-emerald-500/30 text-[10px]" title="Profile published to UC ecosystem.">
+        <CheckCircle2 className="h-2.5 w-2.5 mr-1" /> synced
+      </Badge>
+    )
+  }
+  if (state === "offline") {
+    return (
+      <Badge className="bg-zinc-900 text-zinc-500 border-zinc-800 text-[10px]" title="Sync API not available.">
+        <CloudOff className="h-2.5 w-2.5 mr-1" /> offline
+      </Badge>
+    )
+  }
+  return (
+    <Badge className="bg-red-500/10 text-red-300 border-red-500/30 text-[10px]" title={error || "Sync failed"}>
+      <CloudUpload className="h-2.5 w-2.5 mr-1" /> sync error
+    </Badge>
+  )
+}
+
+function SpecTile({ icon, label, value, sub }: { icon: React.ReactNode; label: string; value: string; sub: string | null }) {
+  return (
+    <div className="rounded-lg border border-white/[.07] bg-zinc-900/40 px-4 py-3">
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-wider text-zinc-500">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="text-sm font-medium text-zinc-100 mt-1 truncate" title={value}>{value}</div>
+      {sub && <div className="text-[11px] text-zinc-400 mt-1 truncate" title={sub}>{sub}</div>}
+    </div>
+  )
+}

--- a/renderer/src/lib/catalog.ts
+++ b/renderer/src/lib/catalog.ts
@@ -70,6 +70,24 @@ export function normalizeCatalogGame(game: any): CatalogGame {
       ? game.has_hv
       : undefined
 
+  // Snake_case → camelCase passthroughs for the structured system requirements
+  // (the website serves them straight from Postgres). Empty/null is preserved
+  // so the DownloadCheckModal can detect "no sysreq data".
+  const minRequirements = game?.minRequirements ?? game?.min_requirements ?? null
+  const recommendedRequirements = game?.recommendedRequirements ?? game?.recommended_requirements ?? null
+  const sizeBytes = typeof game?.sizeBytes === "number"
+    ? game.sizeBytes
+    : typeof game?.size_bytes === "number"
+      ? game.size_bytes
+      : typeof game?.size_bytes === "string" && /^\d+$/.test(game.size_bytes)
+        ? Number(game.size_bytes)
+        : undefined
+  const installedSizeBytes = typeof game?.installedSizeBytes === "number"
+    ? game.installedSizeBytes
+    : typeof game?.installed_size_bytes === "number"
+      ? game.installed_size_bytes
+      : undefined
+
   return {
     ...game,
     appid: String(game?.appid || ""),
@@ -80,12 +98,16 @@ export function normalizeCatalogGame(game: any): CatalogGame {
     screenshots: Array.isArray(game?.screenshots) ? game.screenshots : [],
     release_date: typeof game?.release_date === "string" ? game.release_date : "",
     size: typeof game?.size === "string" ? game.size : "",
+    sizeBytes,
+    installedSizeBytes,
     source: typeof game?.source === "string" && game.source ? game.source : "local",
     store: typeof game?.store === "string" ? game.store : "",
     developer,
     hasCoOp,
     hasHv,
     dlc: Array.isArray(game?.dlc) ? game.dlc : [],
+    minRequirements,
+    recommendedRequirements,
     searchText: normalizeSearchText(`${normalizedName} ${normalizedDescription} ${(Array.isArray(game?.genres) ? game.genres.join(" ") : "")} ${developer}`),
   }
 }

--- a/renderer/src/lib/system-requirements.ts
+++ b/renderer/src/lib/system-requirements.ts
@@ -1,0 +1,226 @@
+import type { GameRequirements } from "@/lib/types"
+
+// ── GPU driver freshness ────────────────────────────────────────────────────
+
+/** How old (in days) before we consider the driver stale enough to warn. */
+const DRIVER_STALE_THRESHOLD_DAYS = 180
+
+const VENDOR_DRIVER_URLS: Record<string, string> = {
+  nvidia: "https://www.nvidia.com/Download/index.aspx",
+  amd: "https://www.amd.com/en/support",
+  intel: "https://www.intel.com/content/www/us/en/download-center/home.html",
+  apple: "https://support.apple.com/en-us/HT213323",
+}
+
+/**
+ * Parse the driver date string returned by the scanner. Windows WMI returns
+ * a DMTF datetime (e.g. "20240115000000.000000-000") for the GPU's driver
+ * date; ISO strings are also accepted.
+ *
+ * Returns null when the input can't be parsed — caller should treat that as
+ * "unknown" and skip the warning.
+ */
+export function parseGpuDriverDate(raw: string | null | undefined): Date | null {
+  if (!raw || typeof raw !== "string") return null
+  // DMTF: YYYYMMDDHHmmss.ffffff±UUU
+  const dmtf = raw.match(/^(\d{4})(\d{2})(\d{2})/)
+  if (dmtf) {
+    const year = Number(dmtf[1])
+    const month = Number(dmtf[2]) - 1
+    const day = Number(dmtf[3])
+    if (year >= 1990 && year <= 2100 && month >= 0 && month < 12 && day >= 1 && day <= 31) {
+      const date = new Date(Date.UTC(year, month, day))
+      return Number.isNaN(date.getTime()) ? null : date
+    }
+  }
+  // ISO 8601 or other Date-parsable input
+  const parsed = new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+export type DriverStatus = {
+  status: "fresh" | "stale" | "unknown"
+  ageDays: number | null
+  driverDate: Date | null
+  vendor: string | null
+  driverPageUrl: string | null
+}
+
+export function evaluateGpuDriver(spec: SystemProfile["spec"] | null | undefined): DriverStatus {
+  const primary = spec?.gpus?.[0]
+  if (!primary) return { status: "unknown", ageDays: null, driverDate: null, vendor: null, driverPageUrl: null }
+  const driverDate = parseGpuDriverDate(primary.driverDate)
+  const vendor = (primary.vendor || "").toLowerCase()
+  const driverPageUrl = VENDOR_DRIVER_URLS[vendor] || null
+  if (!driverDate) {
+    return { status: "unknown", ageDays: null, driverDate: null, vendor: vendor || null, driverPageUrl }
+  }
+  const ageDays = Math.floor((Date.now() - driverDate.getTime()) / (1000 * 60 * 60 * 24))
+  const status: DriverStatus["status"] = ageDays > DRIVER_STALE_THRESHOLD_DAYS ? "stale" : "fresh"
+  return { status, ageDays, driverDate, vendor: vendor || null, driverPageUrl }
+}
+
+
+export type RequirementCheck = {
+  component: "cpu" | "gpu" | "ram" | "storage" | "os" | "directx" | "vulkan"
+  status: "pass" | "warn" | "fail" | "unknown"
+  required: string | null
+  have: string | null
+  detail?: string
+}
+
+export type RequirementVerdict = {
+  status: "pass" | "warn" | "fail" | "unknown"
+  checks: RequirementCheck[]
+  /** Number of hard failures. > 0 means the game won't run. */
+  failCount: number
+  /** Number of partial/warn matches. */
+  warnCount: number
+}
+
+// Loose GPU-tier ranking. We don't try to be authoritative — this is a
+// coarse "can probably run it" heuristic. A real comparator needs a
+// benchmark dataset (Phase 5). Lower index = weaker.
+const GPU_TIERS: Array<{ pattern: RegExp; tier: number }> = [
+  // Intel iGPU / very old
+  { pattern: /\b(hd graphics|uhd graphics|intel hd|intel uhd)\b/i, tier: 1 },
+  { pattern: /\b(gt\s*7\d\d|gtx\s*[567]\d\d|hd\s*[567]\d\d\d|r7\s*\d\d\d)\b/i, tier: 2 },
+  // Mid-range last-gen
+  { pattern: /\b(gtx\s*9\d\d|gtx\s*10[56]0|rx\s*[45]\d\d|rx\s*560|rx\s*570)\b/i, tier: 3 },
+  { pattern: /\b(gtx\s*1070|gtx\s*1080|rx\s*580|rx\s*590|rx\s*5[56]00)\b/i, tier: 4 },
+  { pattern: /\b(rtx\s*20[567]0|gtx\s*16[567]0|rx\s*5700|rx\s*6[56]00|arc\s*a[35]\d\d)\b/i, tier: 5 },
+  { pattern: /\b(rtx\s*30[567]0|rx\s*6[78]00|arc\s*a7\d\d)\b/i, tier: 6 },
+  { pattern: /\b(rtx\s*3080|rtx\s*3090|rtx\s*40[67]0|rx\s*79\d\d|rx\s*7800)\b/i, tier: 7 },
+  { pattern: /\b(rtx\s*40[89]0|rtx\s*50[89]0)\b/i, tier: 8 },
+]
+
+function gpuTier(name: string | null | undefined): number | null {
+  if (!name) return null
+  for (const entry of GPU_TIERS) {
+    if (entry.pattern.test(name)) return entry.tier
+  }
+  return null
+}
+
+function compareCpus(have: string | null, required: string | null): "pass" | "warn" | "unknown" {
+  if (!have || !required) return "unknown"
+  // Very loose: same family + generation rough match. Without a benchmark
+  // table this is mostly informational — we err on the side of "warn".
+  const haveLower = have.toLowerCase()
+  const reqLower = required.toLowerCase()
+  // Intel core family
+  const haveCore = haveLower.match(/i([3579])-(\d+)/)
+  const reqCore = reqLower.match(/i([3579])-(\d+)/)
+  if (haveCore && reqCore) {
+    const haveGen = Number(String(haveCore[2]).slice(0, -3)) || 0
+    const reqGen = Number(String(reqCore[2]).slice(0, -3)) || 0
+    if (Number(haveCore[1]) > Number(reqCore[1])) return "pass"
+    if (Number(haveCore[1]) === Number(reqCore[1]) && haveGen >= reqGen) return "pass"
+    return "warn"
+  }
+  // AMD Ryzen
+  const haveRyzen = haveLower.match(/ryzen\s*([3579])\s*(\d+)/)
+  const reqRyzen = reqLower.match(/ryzen\s*([3579])\s*(\d+)/)
+  if (haveRyzen && reqRyzen) {
+    return Number(haveRyzen[1]) >= Number(reqRyzen[1]) ? "pass" : "warn"
+  }
+  return "unknown"
+}
+
+function gpuListToArray(value: string | string[] | null | undefined): string[] {
+  if (!value) return []
+  return Array.isArray(value) ? value : [value]
+}
+
+export function compareToProfile(
+  spec: SystemProfile["spec"] | null | undefined,
+  requirements: GameRequirements | null | undefined,
+): RequirementVerdict {
+  const checks: RequirementCheck[] = []
+  if (!spec || !requirements) {
+    return { status: "unknown", checks, failCount: 0, warnCount: 0 }
+  }
+
+  // CPU
+  if (requirements.cpu) {
+    const status = compareCpus(spec.cpu.model, requirements.cpu)
+    checks.push({ component: "cpu", status, required: requirements.cpu, have: spec.cpu.model || null })
+  }
+
+  // GPU
+  const reqGpus = gpuListToArray(requirements.gpu)
+  if (reqGpus.length > 0) {
+    const userGpu = spec.gpus[0]?.name || null
+    const userTier = gpuTier(userGpu)
+    const bestReqTier = Math.min(...reqGpus.map((g) => gpuTier(g) ?? 99))
+    let status: RequirementCheck["status"] = "unknown"
+    if (userTier != null && bestReqTier !== 99) {
+      status = userTier >= bestReqTier ? "pass" : userTier === bestReqTier - 1 ? "warn" : "fail"
+    }
+    checks.push({
+      component: "gpu",
+      status,
+      required: reqGpus.join(" / "),
+      have: userGpu,
+    })
+  }
+
+  // RAM
+  if (requirements.ramGb) {
+    const haveGb = (spec.ram.totalBytes || 0) / (1024 ** 3)
+    const status: RequirementCheck["status"] =
+      haveGb >= requirements.ramGb ? "pass" :
+      haveGb >= requirements.ramGb * 0.85 ? "warn" : "fail"
+    checks.push({
+      component: "ram",
+      status,
+      required: `${requirements.ramGb} GB`,
+      have: `${haveGb.toFixed(1)} GB`,
+    })
+  }
+
+  // Storage: compared against the largest free volume.
+  if (requirements.storageGb) {
+    const maxFreeBytes = Math.max(0, ...spec.storage.volumes.map((v) => v.freeBytes || 0))
+    const needBytes = requirements.storageGb * (1024 ** 3)
+    const status: RequirementCheck["status"] = maxFreeBytes >= needBytes ? "pass" : "fail"
+    checks.push({
+      component: "storage",
+      status,
+      required: `${requirements.storageGb} GB free`,
+      have: `${(maxFreeBytes / 1024 ** 3).toFixed(1)} GB free (largest drive)`,
+    })
+  }
+
+  // OS
+  if (requirements.os) {
+    const reqOses = Array.isArray(requirements.os) ? requirements.os : [requirements.os]
+    const haveOs = `${spec.os.name} ${spec.os.version || ""}`.trim()
+    const status: RequirementCheck["status"] =
+      reqOses.some((r) => haveOs.toLowerCase().includes(String(r).toLowerCase().split(" ")[0])) ? "pass" : "warn"
+    checks.push({ component: "os", status, required: reqOses.join(" / "), have: haveOs })
+  }
+
+  // DirectX
+  if (requirements.directx) {
+    const haveDx = Number(spec.graphics.directx) || 0
+    const reqDx = Number(requirements.directx.replace(/[^\d.]/g, "")) || 0
+    const status: RequirementCheck["status"] =
+      reqDx === 0 ? "unknown" : haveDx >= reqDx ? "pass" : "fail"
+    checks.push({
+      component: "directx",
+      status,
+      required: `DirectX ${requirements.directx}`,
+      have: spec.graphics.directx ? `DirectX ${spec.graphics.directx}` : null,
+    })
+  }
+
+  const failCount = checks.filter((c) => c.status === "fail").length
+  const warnCount = checks.filter((c) => c.status === "warn").length
+  const status: RequirementVerdict["status"] =
+    failCount > 0 ? "fail" :
+    warnCount > 0 ? "warn" :
+    checks.length === 0 ? "unknown" : "pass"
+
+  return { status, checks, failCount, warnCount }
+}

--- a/renderer/src/lib/types.ts
+++ b/renderer/src/lib/types.ts
@@ -1,3 +1,19 @@
+export interface GameRequirements {
+  /** Free-text from the game's storefront. Always shown to the user. */
+  raw?: string | null
+  os?: string | string[] | null
+  cpu?: string | null
+  /** Minimum GPU name. May be a list of accepted models. */
+  gpu?: string | string[] | null
+  /** GB of system RAM. */
+  ramGb?: number | null
+  /** GB of free storage required. */
+  storageGb?: number | null
+  directx?: string | null
+  vulkan?: string | null
+  notes?: string | null
+}
+
 export interface Game {
   appid: string
   name: string
@@ -11,6 +27,10 @@ export interface Game {
   hero_logo?: string
   release_date: string
   size: string
+  /** Best-effort numeric size of the downloadable archive(s), in bytes. */
+  sizeBytes?: number
+  /** Best-effort numeric size of the extracted/installed game, in bytes. */
+  installedSizeBytes?: number
   version?: string
   developer: string
   source: string
@@ -24,6 +44,9 @@ export interface Game {
   hasHv?: boolean
   isExternal?: boolean
   externalPath?: string
+  /** System requirements published by the storefront (Phase 4 backend). */
+  minRequirements?: GameRequirements | null
+  recommendedRequirements?: GameRequirements | null
 }
 
 export type GameStats = Record<string, { downloads: number; views: number }>

--- a/renderer/src/vite-env.d.ts
+++ b/renderer/src/vite-env.d.ts
@@ -76,6 +76,93 @@ type GameLinuxConfig = {
 }
 
 declare global {
+  /** Canonical hardware/OS spec captured by the UC system profile scanner. */
+  type SystemProfile = {
+    version: number
+    capturedAt: string
+    scanDurationMs: number
+    fingerprint: string
+    spec: {
+      cpu: {
+        model: string | null
+        vendor: string | null
+        arch: string | null
+        cores: number | null
+        threads: number | null
+        baseClockMhz: number | null
+      }
+      gpus: Array<{
+        name: string | null
+        vendor: string
+        vramBytes: number | null
+        driverVersion: string | null
+        driverDate: string | null
+        videoProcessor?: string | null
+      }>
+      ram: {
+        totalBytes: number
+        modules: number | null
+        speedMhz: number | null
+        channels: string | null
+      }
+      storage: {
+        drives: Array<{ model: string | null; sizeBytes: number | null; mediaType: string | null; interfaceType: string | null }>
+        volumes: Array<{ mount: string | null; sizeBytes: number | null; freeBytes: number | null; fs: string | null; mediaType?: string | null; busType?: string | null }>
+      }
+      os: {
+        platform: string
+        name: string
+        version: string
+        build: string | null
+        arch: string
+        locale: string | null
+      }
+      displays: Array<{ label: string | null; width: number | null; height: number | null; refreshHz: number | null }>
+      graphics: { directx: string | null; vulkan: string | null; opengl: string | null }
+    }
+  }
+
+  /** Per-surface visibility for the user's hardware profile. */
+  type SystemProfileVisibilityTier = 'off' | 'summary' | 'full'
+  type SystemProfileVisibility = {
+    comments: SystemProfileVisibilityTier
+    forums: SystemProfileVisibilityTier
+    profilePublic: SystemProfileVisibilityTier
+    sysreqCheck: 'off' | 'on'
+  }
+
+  /** Pre-download storage reservation check result from window.ucStorage.precheck. */
+  type StoragePrecheckResult = {
+    ok: boolean
+    requiredBytes: number
+    freeBytes: number
+    shortfallBytes: number
+    downloadBytes: number
+    extractBytes: number
+    alreadyReservedBytes: number
+    availableAfterReservation: number
+    mountRoot: string | null
+    humanRequired?: string
+    humanFree?: string
+    humanShortfall?: string
+    humanAvailable?: string
+    error?: string
+  }
+
+  type StorageSummaryResult = {
+    ok: boolean
+    mountRoot?: string | null
+    freeBytes?: number
+    reservedBytes?: number
+    reservedDownloadBytes?: number
+    reservedExtractBytes?: number
+    availableBytes?: number
+    humanFree?: string
+    humanReserved?: string
+    humanAvailable?: string
+    error?: string
+  }
+
   interface Window {
     ucDownloads?: {
       start: (payload: {
@@ -182,6 +269,7 @@ declare global {
     ucApp?: {
       respondToCloseRequest: (shouldProceed: boolean) => Promise<{ ok: boolean; proceeded: boolean }>
       onCloseRequest: (callback: (data: { mode: "quit" | "hide"; extractionCount?: number; appids?: string[] }) => void) => () => void
+      onNavigationAction?: (callback: (data: { action: 'open-system-profile'; autoScan?: boolean }) => void) => () => void
     }
     ucSettings?: {
       get: (key: string) => Promise<any>
@@ -272,9 +360,6 @@ declare global {
       clearLogs: () => Promise<void>
       openLogsFolder: () => Promise<{ ok: boolean; error?: string }>
       shareLogs: (payload?: { baseUrl?: string }) => Promise<{ ok: boolean; error?: string; endpoint?: string; status?: number }>
-    }
-    ucSystem?: {
-      openExternal: (target: string) => Promise<{ ok: boolean; error?: string }>
     }
     ucRpc?: {
       setActivity: (payload: {
@@ -460,8 +545,51 @@ declare global {
         controllerType: string | null
       }>
     }
+    ucSystemProfile?: {
+      getCached: () => Promise<{ ok: boolean; profile: SystemProfile | null; error?: string }>
+      scan: (opts?: { force?: boolean }) => Promise<{ ok: boolean; profile?: SystemProfile; cached?: boolean; error?: string }>
+      summary: () => Promise<{ ok: boolean; summary?: string | null; fingerprint?: string; error?: string }>
+      clearCache: () => Promise<{ ok: boolean; error?: string }>
+      upload: (baseUrl?: string) => Promise<{ ok: boolean; status?: number; fingerprint?: string; summary?: string; error?: string }>
+      serverGetVisibility: (baseUrl?: string) => Promise<{ ok: boolean; status?: number; visibility?: { comments: 'off' | 'summary'; forums: 'off' | 'summary'; profilePublic: 'off' | 'summary' | 'full' } | null; error?: string }>
+      serverSetVisibility: (baseUrl: string | undefined, patch: Partial<{ comments: 'off' | 'summary'; forums: 'off' | 'summary'; profilePublic: 'off' | 'summary' | 'full' }>) => Promise<{ ok: boolean; status?: number; visibility?: { comments: 'off' | 'summary'; forums: 'off' | 'summary'; profilePublic: 'off' | 'summary' | 'full' } | null; error?: string }>
+      serverDelete: (baseUrl?: string) => Promise<{ ok: boolean; status?: number; error?: string }>
+      // Multi-rig + share-a-spec (Phase 5)
+      listDevices: (baseUrl?: string) => Promise<{ ok: boolean; devices?: Array<{ fingerprint: string; deviceName: string | null; summary: string | null; sourceAppVersion: string | null; capturedAt: string; isActive: boolean }>; error?: string }>
+      renameDevice: (baseUrl: string | undefined, fingerprint: string, name: string | null) => Promise<{ ok: boolean; error?: string }>
+      deleteDevice: (baseUrl: string | undefined, fingerprint: string) => Promise<{ ok: boolean; error?: string }>
+      activateDevice: (baseUrl: string | undefined, fingerprint: string) => Promise<{ ok: boolean; fingerprint?: string; error?: string }>
+      listShares: (baseUrl?: string) => Promise<{ ok: boolean; shares?: Array<{ shortCode: string; tier: 'summary' | 'full'; viewCount: number; expiresAt: string | null; createdAt: string }>; error?: string }>
+      createShare: (baseUrl: string | undefined, opts: { tier?: 'summary' | 'full'; expiresInDays?: number | null }) => Promise<{ ok: boolean; shortCode?: string; tier?: 'summary' | 'full'; expiresAt?: string | null; error?: string }>
+      revokeShare: (baseUrl: string | undefined, shortCode: string) => Promise<{ ok: boolean; error?: string }>
+      upgradeSuggest: (baseUrl?: string) => Promise<{
+        ok: boolean
+        status?: number
+        reason?: string
+        error?: string
+        report?: {
+          considered: number
+          smoothCount: number
+          bottleneckedCount: number
+          unknownCount: number
+          primaryUnlockCount: number | null
+          bottlenecks: Array<{
+            component: 'cpu' | 'gpu' | 'ram' | 'storage' | 'directx'
+            gamesAffected: number
+            suggestion: string | null
+            examples: Array<{ appid: string; name: string | null }>
+          }>
+        } | null
+      }>
+    }
+    ucStorage?: {
+      precheck: (opts: { targetPath?: string; downloadBytes: number; declaredInstallBytes?: number }) => Promise<StoragePrecheckResult>
+      summary: (targetPath?: string) => Promise<StorageSummaryResult>
+      snapshot: () => Promise<{ ok: boolean; reservations?: Array<{ id: string; mountRoot: string; downloadBytes: number; extractBytes: number; status: string; createdAt: number }>; error?: string }>
+    }
     ucSystem?: {
       getVolume: () => Promise<{ ok: boolean; volume: number }>
+      openExternal?: (target: string) => Promise<{ ok: boolean; error?: string }>
       setVolume: (level: number) => Promise<{ ok: boolean }>
       getMuted: () => Promise<{ ok: boolean; muted: boolean }>
       setMuted: (muted: boolean) => Promise<{ ok: boolean }>


### PR DESCRIPTION
…tion

Adds an opt-in hardware scanner that powers the wider UC System Profile feature across UC.D and the website. Nothing leaves the machine until the user flips a sharing switch in Settings.

UC.D side (this PR):
- electron/system-profile.cjs: platform-native scanner (PowerShell + Storage Spaces on Windows, /proc + lscpu + lspci on Linux). Maps drive letters to media type so we can tell SSD from HDD per volume. No npm deps, no rebuild.
- electron/storage-reservation.cjs: concurrency-safe pre-download check that reserves downloadBytes + extractBytes (~2x archive, configurable) per drive. Refuses downloads when in-flight reservations would leave too little room.
- electron/main.cjs: IPC handlers for scan/get-cached/upload/visibility/devices/ shares/upgrade-suggest, plus reservation hooks on uc:download-start / download-cancel and extraction-job lifecycle. Adds unioncrax://scan deep-link parsing and a navigation-action queue that drains to the renderer on ready.
- electron/preload.cjs: exposes window.ucSystemProfile, window.ucStorage, and ucApp.onNavigationAction.
- renderer/src/components/SystemProfilePanel.tsx: scan + spec sheet + per- surface visibility toggles + sync status badge + multi-rig device picker + share-link mint/copy/revoke + wishlist upgrade suggester.
- renderer/src/components/DownloadCheckModal.tsx: storage reservation summary (blocks the download button when short on space), per-component sysreq comparison panel, stale GPU driver warning with vendor deep links, and an HDD-vs-SSD install hint.
- renderer/src/lib/system-requirements.ts: client-side comparator + driver staleness eval shared with the modal.
- renderer/src/lib/catalog.ts: snake/camel passthroughs for min_requirements, recommended_requirements, size_bytes, installed_size_bytes from the API.
- renderer/src/app/Layout.tsx + SettingsPage.tsx: routes unioncrax://scan to /settings?section=system&autoScan=1 and auto-fires a fresh scan once the panel mounts.
- renderer/src/vite-env.d.ts + lib/types.ts: SystemProfile, visibility tiers, StoragePrecheckResult, GameRequirements global types.

Companion changes on union-crax.xyz (separate PR): DB tables for profiles / visibility / snapshots / devices / shares, Steam-HTML sysreq parser + backfill script, public profile + comment + forum chip rendering, "Can my PC run" search filter, hardware leaderboards, share-a-spec landing page, and a sidebar-style settings layout with a "Scan with UC.Direct" CTA.