### PR TITLE
Fix toast/activity-bar overlap, overlay stale state, and device-targeted queue

### DIFF
--- a/renderer/src/components/InGameOverlay.tsx
+++ b/renderer/src/components/InGameOverlay.tsx
@@ -475,12 +475,12 @@ export function InGameOverlay() {
                 : <LogoStaticDark className="h-6 w-6" />}
             </div>
             <div className="min-w-0 flex-1">
-              <div className="section-label !text-muted-foreground">Now Playing</div>
-              <div className="truncate text-sm font-semibold text-white leading-tight">
-                {gameInfo?.gameName || currentAppid || 'Game session'}
+              <div className="section-label !text-muted-foreground">{hasSession ? 'Now Playing' : 'UnionCrax'}</div>
+              <div className={`truncate text-sm font-semibold leading-tight ${hasSession ? 'text-white' : 'text-muted-foreground'}`}>
+                {hasSession ? (gameInfo?.gameName || currentAppid) : 'No games running'}
               </div>
             </div>
-            <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-400" />
+            <span className={`h-2 w-2 shrink-0 rounded-full ${hasSession ? 'bg-emerald-400' : 'bg-muted-foreground/40'}`} />
           </div>
           <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/[.08]">
             <div className="h-full rounded-full bg-white/80" style={{ width: `${toastProgress}%`, transition: 'width 50ms linear' }} />
@@ -622,6 +622,21 @@ export function InGameOverlay() {
 
           {/* Scrollable body */}
           <div className="flex-1 overflow-y-auto">
+
+            {/* Stale state — the overlay is open but no game session is being
+                tracked (e.g. the game exited while the panel was up). Make it
+                explicit rather than implying an active session. */}
+            {!hasSession && (
+              <section className="px-4 py-3 border-b border-white/[.05]">
+                <div className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+                  <span className="text-sm font-medium text-muted-foreground">No games running</span>
+                </div>
+                <p className="mt-0.5 text-[11px] text-muted-foreground/60">
+                  Stale overlay state — launch a game to start a session.
+                </p>
+              </section>
+            )}
 
             {/* Now Playing */}
             {hasSession && (

--- a/renderer/src/components/Toaster.tsx
+++ b/renderer/src/components/Toaster.tsx
@@ -89,9 +89,12 @@ export function Toaster() {
 
   if (toasts.length === 0) return null
 
+  // Sits at bottom-24 (not bottom-8) so toasts clear the always-present
+  // DownBar "Activity" pill (fixed at bottom-4). At bottom-8 the two
+  // overlapped and toasts read as tucked behind the activity bar.
   return (
     <div
-      className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[9999] flex flex-col-reverse items-center gap-2 pointer-events-none"
+      className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[9999] flex flex-col-reverse items-center gap-2 pointer-events-none"
       aria-live="polite"
       aria-atomic="false"
     >

--- a/renderer/src/components/WebDownloadQueueConsumer.tsx
+++ b/renderer/src/components/WebDownloadQueueConsumer.tsx
@@ -10,6 +10,10 @@ type QueueEntry = {
   appid: string
   name?: string
   queueSource?: string
+  /** When set, the website pinned this download to a specific PC's system-
+   *  profile fingerprint. Only that device should start it; other devices
+   *  leave it in the queue. Null/absent means "any device" (legacy behaviour). */
+  deviceFingerprint?: string | null
 } & Partial<Game>
 
 /**
@@ -27,6 +31,22 @@ type QueueEntry = {
  * drains.
  */
 const POLL_INTERVAL_MS = 25_000
+
+async function getLocalFingerprint(): Promise<string | null> {
+  try {
+    const res = await window.ucSystemProfile?.getCached?.()
+    if (res?.ok && res.profile?.fingerprint) return res.profile.fingerprint
+  } catch {
+    // fall through to summary
+  }
+  try {
+    const s = await window.ucSystemProfile?.summary?.()
+    if (s?.ok && s.fingerprint) return s.fingerprint
+  } catch {
+    // best-effort
+  }
+  return null
+}
 
 async function removeFromServerQueue(appid: string) {
   try {
@@ -46,6 +66,9 @@ export function WebDownloadQueueConsumer() {
   const { startGameDownload } = useDownloadsActions()
   const { toast } = useToast()
   const runningRef = useRef(false)
+  // This device's own system-profile fingerprint, resolved lazily and cached.
+  // Used to decide whether a device-targeted queue entry belongs to us.
+  const fingerprintRef = useRef<string | null>(null)
   // Keep the latest startGameDownload in a ref so the polling effect doesn't
   // tear down / restart its interval whenever the actions object identity
   // changes.
@@ -69,11 +92,23 @@ export function WebDownloadQueueConsumer() {
         if (!Array.isArray(items) || items.length === 0) return
         if (cancelled) return
 
+        // Resolve our own fingerprint once we need it, so we can tell which
+        // device-targeted entries belong to this PC. Retried on later drains
+        // if it isn't available yet (e.g. the system profile hasn't scanned).
+        if (fingerprintRef.current == null) {
+          fingerprintRef.current = await getLocalFingerprint()
+        }
+        const myFingerprint = fingerprintRef.current
+
         const startedNames: string[] = []
         for (const item of items) {
           if (cancelled) break
           const appid = String(item?.appid || "")
           if (!appid) continue
+          // Device-targeted entry for a different PC — leave it in the queue
+          // (don't start it, don't delete it) so the intended device drains it.
+          const target = item?.deviceFingerprint ? String(item.deviceFingerprint) : null
+          if (target && target !== myFingerprint) continue
           try {
             const game = { source: "web", ...item, appid } as unknown as Game
             await startRef.current(game)


### PR DESCRIPTION
Three fixes:

## 1. Toasts behind the activity bar
The global `Toaster` sat at `bottom-8`, overlapping the always-present `DownBar` "Activity" pill (`bottom-4`). Lifted toasts to `bottom-24` so they clear the bar.

## 2. Overlay no longer implies a session when none is running
In `InGameOverlay`, when there's no tracked session the toast header now reads a muted **"No games running"** (instead of "Now Playing"/"Game session"), and the panel shows an explicit stale-state notice.

## 3. Honor device-targeted queue entries
The website can now pin a queued download to a specific PC's system-profile fingerprint. The queue consumer resolves this device's own fingerprint and **skips (without deleting)** any entry targeted at a different device, so only the intended PC starts it. Untargeted entries (`deviceFingerprint` null) keep the original "drain on any device" behaviour. Pairs with the union-crax.xyz PR.

## Notes
- Could not run typecheck/build in the dev environment (no `node_modules`); changes reviewed by hand.

https://claude.ai/code/session_01BWBVwCCazXsziL41j4sb2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWBVwCCazXsziL41j4sb2M)_